### PR TITLE
Validator-side vector generation

### DIFF
--- a/conversationgenome/llm/LlmLib.py
+++ b/conversationgenome/llm/LlmLib.py
@@ -57,6 +57,16 @@ class LlmLib:
         response = await self.factory_llm.conversation_to_metadata(conversation)
         return response
 
+    async def miner_conversation_to_metadata(self,  conversation):
+        if not self.factory_llm:
+            self.factory_llm = await self.generate_llm_instance()
+            if not self.factory_llm:
+                bt.logging.error("LLM not found. Aborting conversation_to_metadata.")
+                return
+
+        response = await self.factory_llm.miner_conversation_to_metadata(conversation)
+        return response
+
 
 
 if __name__ == "__main__":

--- a/conversationgenome/llm/llm_groq.py
+++ b/conversationgenome/llm/llm_groq.py
@@ -114,6 +114,23 @@ class llm_groq:
 
         return out
 
+    def generate_convo_xml(self, convo):
+        xml = "<conversation id='%d'>" % (83945)
+        #print("CONVO OPENAI", convo)
+        participants = {}
+        for line in convo['lines']:
+            if len(line) != 2:
+                continue
+            #print(line)
+            participant = "p%d" % (line[0])
+            xml += "<%s>%s</%s>" % (participant, line[1], participant)
+            if not participant in participants:
+                participants[participant] = 0
+            # Count number entries for each participant -- may need it later
+            participants[participant] += 1
+        xml += "</conversation>"
+        return (xml, participants)
+
     async def conversation_to_metadata(self,  convo):
         llm_embeddings = llm_openai()
         (xml, participants) = llm_embeddings.generate_convo_xml(convo)
@@ -163,6 +180,47 @@ class llm_groq:
             if self.verbose:
                 print("        Embeddings received: " + ", ".join(tag_logs))
                 print("VECTORS", tag, vectors)
+            out['success'] = 1
+        else:
+            print("No tags returned by OpenAI for Groq", response)
+        return out
+
+    async def miner_conversation_to_metadata(self,  convo):
+        #llm_embeddings = llm_openai()
+        (xml, participants) = self.generate_convo_xml(convo)
+        tags = None
+        out = {"tags":{}}
+
+        response = await self.call_llm_tag_function(convoXmlStr=xml, participants=participants)
+        if not response:
+            print("No tagging response. Aborting")
+            return None
+        elif not response['success']:
+            print(f"Tagging failed: {response}. Aborting")
+            return response
+
+        content = Utils.get(response, 'content')
+        if content:
+            lines = content.replace("\n",",")
+            tag_dict = {}
+            parts = lines.split(",")
+            if len(parts) > 1:
+                for part in parts:
+                    tag = part.strip().lower()
+                    if tag[0:1] == "<":
+                        continue
+                    tag_dict[tag] = True
+            else:
+                print("Less that 2 tags returned. Aborting.")
+                tags = []
+            tags = list(tag_dict.keys())
+        else:
+            tags = []
+        tags = Utils.clean_tags(tags)
+
+        if len(tags) > 0:
+            out['tags'] = tags
+            out['vectors'] = {}
             out['success'] = 1
         else:
             print("No tags returned by OpenAI for Groq", response)

--- a/conversationgenome/miner/MinerLib.py
+++ b/conversationgenome/miner/MinerLib.py
@@ -36,10 +36,11 @@ class MinerLib:
         if not dryrun:
             llml = LlmLib()
             lines = copy.deepcopy(conversation_window)
-            result = await llml.conversation_to_metadata({"lines":lines})
+            result = await llml.miner_conversation_to_metadata({"lines":lines})
             tags = Utils.get(result, 'tags')
             out["tags"] = tags
-            out["vectors"] = Utils.get(result, 'vectors', {})
+            #out["vectors"] = Utils.get(result, 'vectors', {})
+            out["vectors"] = {}
             num_tags = len(Utils.get(out, 'tags', []))
             bt.logging.info(f"Miner: Mined {num_tags} vectors and tags")
 

--- a/conversationgenome/validator/evaluator.py
+++ b/conversationgenome/validator/evaluator.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from conversationgenome.utils.Utils import Utils
 from conversationgenome.ConfigLib import c
+from conversationgenome.llm.LlmLib import LlmLib
 
 from conversationgenome.mock.MockBt import MockBt
 
@@ -40,6 +41,40 @@ class Evaluator:
         "mean_score": 0.25,
         "max_score": 0.1,
     }
+
+    async def get_miner_embeddings(self, tags):
+        bt.logging.debug("Generating Vali-Side Vectors")
+
+        out = {"tags":{}}
+        if not Utils.empty(tags):
+            if self.verbose:
+                print(f"------- Found tags: {tags}. Getting vectors for tags...")
+            out['tags'] = tags
+            out['vectors'] = {}
+            tag_logs = []
+
+            if self.factory_llm:
+                for tag in tags:
+                    try: 
+                        vectors = await self.factory_llm.get_vector_embeddings(tag)
+                    except: 
+                        bt.logging.debug("Error with factory LLM")
+                    if not vectors:
+                        bt.logging.debug(f"ERROR -- no vectors for tag: {tag} vector response: {vectors}")
+                    else:
+                        tag_logs.append(f"{tag}={len(vectors)}vs")
+                    out['vectors'][tag] = {"vectors":vectors}
+                if self.verbose:
+                    print("        Embeddings received: " + ", ".join(tag_logs))
+                    print("VECTORS", tag, vectors)
+                out['success'] = 1
+            else:
+                out=None
+        else:
+            bt.logging.debug("No tags returned by OpenAI", response)
+        bt.logging.debug("Vali-Side Vectors Generated")
+        return out
+
 
     # Tag all the vectors from all the tags and return set of vectors defining the neighborhood
     async def calculate_semantic_neighborhood(self, conversation_metadata, tag_count_ceiling=None):
@@ -119,6 +154,12 @@ class Evaluator:
             verbose = self.verbose
         final_scores = []
         now = datetime.now(timezone.utc)
+
+        try: 
+            self.LLM = LlmLib()
+            self.factory_llm= await self.LLM.generate_llm_instance()
+        except: 
+            bt.logging.error("Evaluator LLM not created")
 
         full_conversation_neighborhood = await self.calculate_semantic_neighborhood(full_convo_metadata)
         if verbose:
@@ -231,7 +272,27 @@ class Evaluator:
     async def calc_scores(self, full_convo_metadata, full_conversation_neighborhood, miner_result):
         full_convo_tags = full_convo_metadata['tags']
         tags = miner_result['tags']
-        tag_vector_dict = miner_result['vectors']
+
+        #original tag vector dict
+        #tag_vector_dict = miner_result['vectors']
+
+        tag_vector_dict = {}
+        vali_side_tag_vector_dict = {}
+
+        #Set Validator-Side Embeddings
+        bt.logging.info("Getting Validator-Side Embeddings")
+        try: 
+            temp_out = await self.get_miner_embeddings(tags)
+            vali_side_tag_vector_dict = temp_out['vectors']
+        except: 
+            bt.logging.info("Error Getting Validator-side Embeddings.")
+
+        if vali_side_tag_vector_dict:
+            bt.logging.info("Validator-Side Embeddings Generated")
+            tag_vector_dict=vali_side_tag_vector_dict
+        else: 
+            bt.logging.info("Validator-Side Embeddings are Empty. ")
+
         scores = []
         scores_both = []
         scores_unique = []
@@ -253,7 +314,7 @@ class Evaluator:
             is_unique = False
             if tag in diff['unique_2']:
                 is_unique = True
-            #bt.logging.info(example, resp2)
+            
             if not tag in tag_vector_dict:
                 bt.logging.error(f"No vectors found for tag '{tag}'. Score of 0. Unique: {is_unique}")
                 scores.append(0)
@@ -273,8 +334,11 @@ class Evaluator:
                 Utils.append_log(log_path, f"Evaluator Score for '{tag}': {score} -- Unique: {is_unique}")
         bt.logging.info(f"Scores num: {len(scores)} num of Unique tags: {len(scores_unique)} num of full convo tags: {len(full_convo_tags)}")
 
+        print(f"\n\nnew SCORES FROM VALI-SIDE EMBEDDINGS: {scores} | {scores_both} | {scores_unique}\n\n")
+
         return (scores, scores_both, scores_unique, diff)
 
+    
 if __name__ == "__main__":
     bt.logging.info("Setting up test data...")
 


### PR DESCRIPTION
this only handles the vector generation on the validator side, and fixes the immediate problem of potentially fraudulent tag/vector combinations. I believe there are still two more steps necessary

- [x] amend validator code to ignore miner vectors and generate embeddings on validator side only
- [x] Amend miner code to not generate embeddings anymore. OpenAI Key not necessary if using other LLM (except for in testing)
- [ ] amend testing suite to use a different embeddings model than openAI for testing