### PR TITLE
Redistribution

### DIFF
--- a/conversationgenome/__init__.py
+++ b/conversationgenome/__init__.py
@@ -15,7 +15,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "1.94.16"
+__version__ = "2.0.17"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/conversationgenome/base/validator.py
+++ b/conversationgenome/base/validator.py
@@ -379,7 +379,14 @@ class BaseValidatorNeuron(BaseNeuron):
             self.step = state["step"]
             self.scores = state["scores"]
             self.hotkeys = state["hotkeys"]
-            self.ema_scores = state["ema_scores"]
+            
+            # Check if ema_scores exists in the state, if not, initialize it
+            if "ema_scores" in state:
+                self.ema_scores = state["ema_scores"]
+            else:
+                bt.logging.info("ema_scores not found in saved state. Initializing with default values.")
+                # Initialize ema_scores with the same shape as scores
+                self.ema_scores = torch.ones_like(self.scores) / len(self.scores)
 
             try:
                 bt.logging.debug(f"Loaded state file. Step: {self.step} Num scores: {len(self.scores)} Sum scores: {torch.sum(self.scores)} Num hotkeys: {len(self.hotkeys)}")

--- a/conversationgenome/base/validator.py
+++ b/conversationgenome/base/validator.py
@@ -329,6 +329,7 @@ class BaseValidatorNeuron(BaseNeuron):
         Performs exponential moving average on the scores based on the rewards received from the miners,
         then normalizes, applies a non-linear transformation, and renormalizes the scores.
         """
+        self.ema_scores = self.ema_scores.to(self.scores.device)
         # NaN handling and UID tensor preparation (unchanged)
         if torch.isnan(rewards).any():
             bt.logging.warning(f"NaN values detected in rewards: {rewards}")
@@ -386,6 +387,7 @@ class BaseValidatorNeuron(BaseNeuron):
                 "step": self.step,
                 "scores": self.scores,
                 "hotkeys": self.hotkeys,
+                "ema_scores": self.ema_scores,
             },
             state_path,
         )
@@ -405,6 +407,7 @@ class BaseValidatorNeuron(BaseNeuron):
             self.step = state["step"]
             self.scores = state["scores"]
             self.hotkeys = state["hotkeys"]
+            self.ema_scores = state["ema_scores"]
 
             try:
                 bt.logging.debug(f"Loaded state file. Step: {self.step} Num scores: {len(self.scores)} Sum scores: {torch.sum(self.scores)} Num hotkeys: {len(self.hotkeys)}")

--- a/conversationgenome/validator/ValidatorLib.py
+++ b/conversationgenome/validator/ValidatorLib.py
@@ -6,6 +6,7 @@ import asyncio
 import math
 import os
 import numpy as np
+import torch
 
 
 from conversationgenome.utils.Utils import Utils
@@ -269,5 +270,49 @@ class ValidatorLib:
         bt.logging.info("Quick test for LLM")
         llml = LlmLib()
         await llml.test_tagging()
+
+
+    def update_scores(self, rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power):
+        # NaN handling and UID tensor preparation (unchanged)
+        if torch.isnan(rewards).any():
+            bt.logging.warning(f"NaN values detected in rewards: {rewards}")
+            rewards = torch.nan_to_num(rewards, 0)
+
+        if isinstance(uids, torch.Tensor):
+            uids_tensor = uids.clone().detach()
+        else:
+            uids_tensor = torch.tensor(uids, dtype=torch.long, device=device)
+
+        uids_tensor = uids_tensor.to(scores.device)
+        rewards = rewards.to(scores.device)
+
+        # Scatter rewards
+        scattered_rewards: torch.FloatTensor = ema_scores.scatter(
+            0, uids_tensor, rewards
+        ).to(device)
+
+        # Update EMA scores
+        alpha: float = moving_average_alpha
+        ema_scores = alpha * scattered_rewards + (1 - alpha) * ema_scores
+
+        # Normalize EMA scores
+        sum_scores = torch.sum(ema_scores)
+        if sum_scores > 0:
+            normalized_scores = ema_scores / sum_scores
+        else:
+            normalized_scores = torch.ones_like(ema_scores) / neurons
+
+        # Apply non-linear transformation
+        transformed_scores = torch.pow(normalized_scores, nonlinear_power)
+
+        # Renormalize
+        sum_transformed = torch.sum(transformed_scores)
+        if sum_transformed > 0:
+            scores = transformed_scores / sum_transformed
+        else:
+            scores = torch.ones_like(transformed_scores) / neurons
+
+        bt.logging.debug(f"Updated final scores: {scores}")
+        return scores, ema_scores
 
 

--- a/conversationgenome/validator/ValidatorLib.py
+++ b/conversationgenome/validator/ValidatorLib.py
@@ -275,7 +275,8 @@ class ValidatorLib:
     def update_scores(self, rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power):
         # NaN handling and UID tensor preparation (unchanged)
         if torch.isnan(rewards).any():
-            bt.logging.warning(f"NaN values detected in rewards: {rewards}")
+            if self.verbose:
+                bt.logging.warning(f"NaN values detected in rewards: {rewards}")
             rewards = torch.nan_to_num(rewards, 0)
 
         if isinstance(uids, torch.Tensor):

--- a/tests/test_ema.py
+++ b/tests/test_ema.py
@@ -1,0 +1,39 @@
+import pytest
+import random
+import unittest
+import torch
+
+from conversationgenome.ConfigLib import c
+from conversationgenome.utils.Utils import Utils
+#
+#from conversationgenome.validator.ValidatorLib import ValidatorLib
+from typing import List
+
+verbose = True
+
+bt = None
+try:
+    import bittensor as bt
+except:
+    if verbose:
+        print("bittensor not installed")
+    bt = MockBt()
+
+class TemplateEmaTestCase(unittest.TestCase):
+    verbose = True
+
+    def setUp(self):
+        pass
+
+    def test_nan(self):
+       uids = [1,2,3]
+       ft = torch.FloatTensor([0.1,0.2,0.3])
+       print(f"Testing: ", ft, uids)
+       ema_scores = self.update_scores(ft, uids)
+       assert ema_scores[0] == 0.4
+       assert ema_scores[1] == 0.5
+       assert ema_scores[2] == 0.6
+
+
+    def update_scores(self, rewards: torch.FloatTensor, uids: List[int]):
+        return torch.FloatTensor([0.4,0.5,0.6])

--- a/tests/test_ema.py
+++ b/tests/test_ema.py
@@ -39,7 +39,7 @@ class TemplateEmaTestCase(unittest.TestCase):
        nonlinear_power = 3
        #print(f"Testing: ", rewards, uids)
        scores, ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power)
-       print(f"Testing nan: ", scores, ema_scores)
+       #print(f"Testing nan: ", scores, ema_scores)
        assert torch.isnan(ema_scores).any() == False
        assert torch.isnan(scores).any() == False
        assert ema_scores[0].item() == pytest.approx(0.1,abs=1e-3)
@@ -65,7 +65,7 @@ class TemplateEmaTestCase(unittest.TestCase):
        nonlinear_power = 3
        #print(f"Testing: ", rewards, uids)
        scores, ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power)
-       print(f"Testing great variation: ", scores, ema_scores)
+       #print(f"Testing great variation: ", scores, ema_scores)
        assert torch.isnan(ema_scores).any() == False
        assert torch.isnan(scores).any() == False
        assert ema_scores[0].item() == pytest.approx(0.1,abs=1e-3)
@@ -90,7 +90,7 @@ class TemplateEmaTestCase(unittest.TestCase):
        neurons = 5
        nonlinear_power = 3
        scores, ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power)
-       print(f"Testing small variation: ", scores, ema_scores)
+       #print(f"Testing small variation: ", scores, ema_scores)
        assert torch.isnan(ema_scores).any() == False
        assert torch.isnan(scores).any() == False
        assert ema_scores[0].item() == pytest.approx(0.2900, abs=1e-3)
@@ -116,7 +116,7 @@ class TemplateEmaTestCase(unittest.TestCase):
        nonlinear_power = 3
        scores, ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power)
        
-       print(f"Testing no variation: ", scores, ema_scores)
+       #print(f"Testing no variation: ", scores, ema_scores)
        assert torch.isnan(ema_scores).any() == False
        assert torch.isnan(scores).any() == False
        assert ema_scores[0].item() == pytest.approx(0.1,abs=1e-3)

--- a/tests/test_ema.py
+++ b/tests/test_ema.py
@@ -28,27 +28,30 @@ class TemplateEmaTestCase(unittest.TestCase):
         pass
 
     def test_nan(self):
+       thisdevice = "cuda" if torch.cuda.is_available() else "cpu"
        uids = [1,2,3]
-       ft = torch.FloatTensor([0.1, float('nan') ,0.3])
-       assert torch.isnan(ft).any() == True
-       print(f"Testing: ", ft, uids)
-       ema_scores = self.update_scores(ft, uids)
+       rewards = torch.tensor([0.1, float('nan') ,0.3],device=thisdevice)
+       scores = torch.tensor([0.004455, 0.035550, 0.120000, 0.284445, 0.555550],device=thisdevice)
+       ema_scores = torch.tensor([0.1,0.2,0.3,0.4,0.5],device=thisdevice)
+       moving_average_alpha = 0.1
+       device = "cuda"
+       neurons = 5
+       nonlinear_power = 3
+       #print(f"Testing: ", rewards, uids)
+       scores, ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power)
+       print(f"Testing nan: ", scores, ema_scores)
        assert torch.isnan(ema_scores).any() == False
-       assert ema_scores[0] == 0.1
-       assert ema_scores[1] == 0.0
-       assert ema_scores[2] == 0.3
-
-    def test_out_of_range(self):
-       uids = [1,2,3]
-       ft = torch.FloatTensor([10.1, 0.2 ,-0.3])
-       print(f"Testing: ", ft, uids)
-       ema_scores = self.update_scores(ft, uids)
-       assert torch.isnan(ema_scores).any() == False
-       assert ema_scores[0] == 1.0
-       assert ema_scores[1] == 0.2
-       assert ema_scores[2] == 0.0
-
-    #rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power
+       assert torch.isnan(scores).any() == False
+       assert ema_scores[0].item() == pytest.approx(0.1,abs=1e-3)
+       assert ema_scores[1].item() == pytest.approx(0.1900,abs=1e-3)
+       assert ema_scores[2].item() == pytest.approx(0.2700,abs=1e-3)       
+       assert ema_scores[3].item() == pytest.approx(0.3900,abs=1e-3)
+       assert ema_scores[4].item() == pytest.approx(0.5,abs=1e-3)
+       assert scores[0].item() == pytest.approx(0.0047,abs=1e-3)
+       assert scores[1].item() == pytest.approx(0.0324,abs=1e-3)
+       assert scores[2].item() == pytest.approx(0.0929,abs=1e-3)
+       assert scores[3].item() == pytest.approx(0.2800,abs=1e-3)
+       assert scores[4].item() == pytest.approx(0.5900,abs=1e-3)
 
     def test_great_score_variation(self):
        thisdevice = "cuda" if torch.cuda.is_available() else "cpu"
@@ -79,9 +82,9 @@ class TemplateEmaTestCase(unittest.TestCase):
     def test_small_variation(self):
        thisdevice = "cuda" if torch.cuda.is_available() else "cpu"
        uids = [1,2,3]
-       rewards = torch.tensor([0.49, 0.5, 0.51],device=thisdevice)
-       scores = torch.tensor([0.004455, 0.035550, 0.120000, 0.284445, 0.555550],device=thisdevice)
-       ema_scores = torch.tensor([0.1,0.2,0.3,0.4,0.5],device=thisdevice)
+       rewards = torch.tensor([0.285, 0.295, 0.32],device=thisdevice)
+       scores = torch.tensor([0.174646, 0.183967, 0.193342, 0.213330, 0.234716],device=thisdevice)
+       ema_scores = torch.tensor([0.29,0.295,0.3,0.31,0.32],device=thisdevice)
        moving_average_alpha = 0.1
        device = "cuda"
        neurons = 5
@@ -90,16 +93,16 @@ class TemplateEmaTestCase(unittest.TestCase):
        print(f"Testing small variation: ", scores, ema_scores)
        assert torch.isnan(ema_scores).any() == False
        assert torch.isnan(scores).any() == False
-       assert ema_scores[0].item() == pytest.approx(0.1, abs=1e-3)
-       assert ema_scores[1].item() == pytest.approx(0.2290, abs=1e-3)
-       assert ema_scores[2].item() == pytest.approx(0.3200, abs=1e-3)
-       assert ema_scores[3].item() == pytest.approx(0.4110, abs=1e-3)
-       assert ema_scores[4].item() == pytest.approx(0.5, abs=1e-3)
-       assert scores[0].item() == pytest.approx(0.0042, abs=1e-3)
-       assert scores[1].item() == pytest.approx(0.0500, abs=1e-3)
-       assert scores[2].item() == pytest.approx(0.1364, abs=1e-3)
-       assert scores[3].item() == pytest.approx(0.2890, abs=1e-3)
-       assert scores[4].item() == pytest.approx(0.5204, abs=1e-3)
+       assert ema_scores[0].item() == pytest.approx(0.2900, abs=1e-3)
+       assert ema_scores[1].item() == pytest.approx(0.2940, abs=1e-3)
+       assert ema_scores[2].item() == pytest.approx(0.2995, abs=1e-3)
+       assert ema_scores[3].item() == pytest.approx(0.3110, abs=1e-3)
+       assert ema_scores[4].item() == pytest.approx(0.3200, abs=1e-3)
+       assert scores[0].item() == pytest.approx(0.1748, abs=1e-3)
+       assert scores[1].item() == pytest.approx(0.1821, abs=1e-3)
+       assert scores[2].item() == pytest.approx(0.1926, abs=1e-3)
+       assert scores[3].item() == pytest.approx(0.2156, abs=1e-3)
+       assert scores[4].item() == pytest.approx(0.2349, abs=1e-3)
 
     def test_no_variation(self):
        thisdevice = "cuda" if torch.cuda.is_available() else "cpu"

--- a/tests/test_ema.py
+++ b/tests/test_ema.py
@@ -46,8 +46,39 @@ class TemplateEmaTestCase(unittest.TestCase):
        assert ema_scores[1] == 0.2
        assert ema_scores[2] == 0.0
 
+    def test_great_score_variation(self):
+       uids = [1,2,3]
+       ft = torch.FloatTensor([0.1, 0.5, 1.0])
+       print(f"Testing: ", ft, uids)
+       ema_scores = self.update_scores(ft, uids)
+       assert torch.isnan(ema_scores).any() == False
+       assert ema_scores[0] == 1.0
+       assert ema_scores[1] == 0.2
+       assert ema_scores[2] == 0.0
+
+    def test_small_variation(self):
+       uids = [1,2,3]
+       ft = torch.FloatTensor([0.47, 0.5, 0.52])
+       print(f"Testing: ", ft, uids)
+       ema_scores = self.update_scores(ft, uids)
+       assert torch.isnan(ema_scores).any() == False
+       assert ema_scores[0] == 0.48
+       assert ema_scores[1] == 0.5
+       assert ema_scores[2] == 0.51
+
+    def test_no_variation(self):
+       uids = [1,2,3]
+       ft = torch.FloatTensor([0.5, 0.5, 0.5])
+       print(f"Testing: ", ft, uids)
+       ema_scores = self.update_scores(ft, uids)
+       assert torch.isnan(ema_scores).any() == False
+       assert ema_scores[0] == 0.5
+       assert ema_scores[1] == 0.5
+       assert ema_scores[2] == 0.5
 
 
     def update_scores(self, rewards: torch.FloatTensor, uids: List[int]):
         #return torch.FloatTensor([0.4,0.5,0.6])
-        return torch.nan_to_num(rewards, 0.0)
+        rewards = torch.nan_to_num(rewards, 0.0)
+        rewards = torch.clamp(rewards, min=0.0, max=1.0)
+        return rewards

--- a/tests/test_ema.py
+++ b/tests/test_ema.py
@@ -25,6 +25,7 @@ class TemplateEmaTestCase(unittest.TestCase):
 
     def setUp(self):
         self.vl=ValidatorLib()
+        self.vl.verbose=False
         pass
 
     def test_nan(self):

--- a/tests/test_ema.py
+++ b/tests/test_ema.py
@@ -6,7 +6,7 @@ import torch
 from conversationgenome.ConfigLib import c
 from conversationgenome.utils.Utils import Utils
 #
-#from conversationgenome.validator.ValidatorLib import ValidatorLib
+from conversationgenome.validator.ValidatorLib import ValidatorLib
 from typing import List
 
 verbose = True
@@ -21,8 +21,10 @@ except:
 
 class TemplateEmaTestCase(unittest.TestCase):
     verbose = True
+    vl= None
 
     def setUp(self):
+        self.vl=ValidatorLib()
         pass
 
     def test_nan(self):
@@ -46,35 +48,84 @@ class TemplateEmaTestCase(unittest.TestCase):
        assert ema_scores[1] == 0.2
        assert ema_scores[2] == 0.0
 
+    #rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power
+
     def test_great_score_variation(self):
+       thisdevice = "cuda" if torch.cuda.is_available() else "cpu"
        uids = [1,2,3]
-       ft = torch.FloatTensor([0.1, 0.5, 1.0])
-       print(f"Testing: ", ft, uids)
-       ema_scores = self.update_scores(ft, uids)
+       rewards = torch.tensor([0.1, 0.5, 1.0],device=thisdevice)
+       scores = torch.tensor([0.004455, 0.035550, 0.120000, 0.284445, 0.555550],device=thisdevice)
+       ema_scores = torch.tensor([0.1,0.2,0.3,0.4,0.5],device=thisdevice)
+       moving_average_alpha = 0.1
+       device = "cuda"
+       neurons = 5
+       nonlinear_power = 3
+       #print(f"Testing: ", rewards, uids)
+       scores, ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power)
+       print(f"Testing great variation: ", scores, ema_scores)
        assert torch.isnan(ema_scores).any() == False
-       assert ema_scores[0] == 1.0
-       assert ema_scores[1] == 0.2
-       assert ema_scores[2] == 0.0
+       assert torch.isnan(scores).any() == False
+       assert ema_scores[0].item() == pytest.approx(0.1,abs=1e-3)
+       assert ema_scores[1].item() == pytest.approx(0.1900,abs=1e-3)
+       assert ema_scores[2].item() == pytest.approx(0.3200,abs=1e-3)       
+       assert ema_scores[3].item() == pytest.approx(0.4600,abs=1e-3)
+       assert ema_scores[4].item() == pytest.approx(0.5,abs=1e-3)
+       assert scores[0].item() == pytest.approx(0.0038,abs=1e-3)
+       assert scores[1].item() == pytest.approx(0.0261,abs=1e-3)
+       assert scores[2].item() == pytest.approx(0.1246,abs=1e-3)
+       assert scores[3].item() == pytest.approx(0.3702,abs=1e-3)
+       assert scores[4].item() == pytest.approx(0.4754,abs=1e-3)
 
     def test_small_variation(self):
+       thisdevice = "cuda" if torch.cuda.is_available() else "cpu"
        uids = [1,2,3]
-       ft = torch.FloatTensor([0.47, 0.5, 0.52])
-       print(f"Testing: ", ft, uids)
-       ema_scores = self.update_scores(ft, uids)
+       rewards = torch.tensor([0.49, 0.5, 0.51],device=thisdevice)
+       scores = torch.tensor([0.004455, 0.035550, 0.120000, 0.284445, 0.555550],device=thisdevice)
+       ema_scores = torch.tensor([0.1,0.2,0.3,0.4,0.5],device=thisdevice)
+       moving_average_alpha = 0.1
+       device = "cuda"
+       neurons = 5
+       nonlinear_power = 3
+       scores, ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power)
+       print(f"Testing small variation: ", scores, ema_scores)
        assert torch.isnan(ema_scores).any() == False
-       assert ema_scores[0] == 0.48
-       assert ema_scores[1] == 0.5
-       assert ema_scores[2] == 0.51
+       assert torch.isnan(scores).any() == False
+       assert ema_scores[0].item() == pytest.approx(0.1, abs=1e-3)
+       assert ema_scores[1].item() == pytest.approx(0.2290, abs=1e-3)
+       assert ema_scores[2].item() == pytest.approx(0.3200, abs=1e-3)
+       assert ema_scores[3].item() == pytest.approx(0.4110, abs=1e-3)
+       assert ema_scores[4].item() == pytest.approx(0.5, abs=1e-3)
+       assert scores[0].item() == pytest.approx(0.0042, abs=1e-3)
+       assert scores[1].item() == pytest.approx(0.0500, abs=1e-3)
+       assert scores[2].item() == pytest.approx(0.1364, abs=1e-3)
+       assert scores[3].item() == pytest.approx(0.2890, abs=1e-3)
+       assert scores[4].item() == pytest.approx(0.5204, abs=1e-3)
 
     def test_no_variation(self):
+       thisdevice = "cuda" if torch.cuda.is_available() else "cpu"
        uids = [1,2,3]
-       ft = torch.FloatTensor([0.5, 0.5, 0.5])
-       print(f"Testing: ", ft, uids)
-       ema_scores = self.update_scores(ft, uids)
+       rewards = torch.tensor([0.5, 0.5, 0.5],device=thisdevice)
+       scores = torch.tensor([0.004455, 0.035550, 0.120000, 0.284445, 0.555550],device=thisdevice)
+       ema_scores = torch.tensor([0.1,0.2,0.3,0.4,0.5],device=thisdevice)
+       moving_average_alpha = 0.1
+       device = "cuda"
+       neurons = 5
+       nonlinear_power = 3
+       scores, ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power)
+       
+       print(f"Testing no variation: ", scores, ema_scores)
        assert torch.isnan(ema_scores).any() == False
-       assert ema_scores[0] == 0.5
-       assert ema_scores[1] == 0.5
-       assert ema_scores[2] == 0.5
+       assert torch.isnan(scores).any() == False
+       assert ema_scores[0].item() == pytest.approx(0.1,abs=1e-3)
+       assert ema_scores[1].item() == pytest.approx(0.2300,abs=1e-3)
+       assert ema_scores[2].item() == pytest.approx(0.3200,abs=1e-3)       
+       assert ema_scores[3].item() == pytest.approx(0.4100,abs=1e-3)
+       assert ema_scores[4].item() == pytest.approx(0.5,abs=1e-3)
+       assert scores[0].item() == pytest.approx(0.0042,abs=1e-3)
+       assert scores[1].item() == pytest.approx(0.0507,abs=1e-3)
+       assert scores[2].item() == pytest.approx(0.1366,abs=1e-3)
+       assert scores[3].item() == pytest.approx(0.2873,abs=1e-3)
+       assert scores[4].item() == pytest.approx(0.5211,abs=1e-3)
 
 
     def update_scores(self, rewards: torch.FloatTensor, uids: List[int]):

--- a/tests/test_ema.py
+++ b/tests/test_ema.py
@@ -36,6 +36,17 @@ class TemplateEmaTestCase(unittest.TestCase):
        assert ema_scores[1] == 0.0
        assert ema_scores[2] == 0.3
 
+    def test_out_of_range(self):
+       uids = [1,2,3]
+       ft = torch.FloatTensor([10.1, 0.2 ,-0.3])
+       print(f"Testing: ", ft, uids)
+       ema_scores = self.update_scores(ft, uids)
+       assert torch.isnan(ema_scores).any() == False
+       assert ema_scores[0] == 1.0
+       assert ema_scores[1] == 0.2
+       assert ema_scores[2] == 0.0
+
+
 
     def update_scores(self, rewards: torch.FloatTensor, uids: List[int]):
         #return torch.FloatTensor([0.4,0.5,0.6])

--- a/tests/test_ema.py
+++ b/tests/test_ema.py
@@ -27,7 +27,7 @@ class TemplateEmaTestCase(unittest.TestCase):
 
     def test_nan(self):
        uids = [1,2,3]
-       ft = torch.FloatTensor([0.1,0.2,0.3])
+       ft = torch.FloatTensor([0.1,float('nan'),0.3])
        print(f"Testing: ", ft, uids)
        ema_scores = self.update_scores(ft, uids)
        assert ema_scores[0] == 0.4

--- a/tests/test_ema.py
+++ b/tests/test_ema.py
@@ -27,13 +27,16 @@ class TemplateEmaTestCase(unittest.TestCase):
 
     def test_nan(self):
        uids = [1,2,3]
-       ft = torch.FloatTensor([0.1,float('nan'),0.3])
+       ft = torch.FloatTensor([0.1, float('nan') ,0.3])
+       assert torch.isnan(ft).any() == True
        print(f"Testing: ", ft, uids)
        ema_scores = self.update_scores(ft, uids)
-       assert ema_scores[0] == 0.4
-       assert ema_scores[1] == 0.5
-       assert ema_scores[2] == 0.6
+       assert torch.isnan(ema_scores).any() == False
+       assert ema_scores[0] == 0.1
+       assert ema_scores[1] == 0.0
+       assert ema_scores[2] == 0.3
 
 
     def update_scores(self, rewards: torch.FloatTensor, uids: List[int]):
-        return torch.FloatTensor([0.4,0.5,0.6])
+        #return torch.FloatTensor([0.4,0.5,0.6])
+        return torch.nan_to_num(rewards, 0.0)


### PR DESCRIPTION
changes to base validator class to introduce non-linear transformation and renormalization prior to setting weights. This was inspired by subnet 19 transformation & renormalization: https://github.com/namoray/vision/blob/ab5dcc682575f1bf971c77054e5028189cb1c947/validation/weight_setting/calculations.py#L79

adds a self.ema_score tensor to the validator base class, stores exponential moving average as well as transformed and normalized scores as self.sores. every time new scores come in, the validator recalculates the EMA score, normalizes these scores, transforms them by cubing, and then renormalizes, finally updating self.scores. 