### PR TITLE
Fix outlier validator

### DIFF
--- a/conversationgenome/base/validator.py
+++ b/conversationgenome/base/validator.py
@@ -354,8 +354,11 @@ class BaseValidatorNeuron(BaseNeuron):
         then normalizes, applies a non-linear transformation, and renormalizes the scores.
         """
 
+        #first, find unavailable uids:
+        unavailable_uids = [i for i in range(self.metagraph.n) if not check_uid_availability(self.metagraph,i,self.config.neuron.vpermit_tao_limit)]
+
         vl = ValidatorLib()
-        updated_scores, updated_ema_scores = vl.update_scores(rewards, uids, self.ema_scores, self.scores, self.config.neuron.moving_average_alpha, self.device, self.metagraph.n, self.nonlinear_power)
+        updated_scores, updated_ema_scores = vl.update_scores(rewards, uids, self.ema_scores, self.scores, self.config.neuron.moving_average_alpha, self.device, self.metagraph.n, self.nonlinear_power, unavailable_uids)
 
         if updated_scores.size > 0 and updated_ema_scores.size > 0 and not np.isnan(updated_scores).any() and not np.isnan(updated_ema_scores).any():
             self.scores = updated_scores

--- a/conversationgenome/base/validator.py
+++ b/conversationgenome/base/validator.py
@@ -35,6 +35,7 @@ from conversationgenome.base.neuron import BaseNeuron
 from conversationgenome.mock.mock import MockDendrite
 from conversationgenome.utils.config import add_validator_args
 from conversationgenome.validator.ValidatorLib import ValidatorLib
+from conversationgenome.utils.uids import check_uid_availability
 
 
 class BaseValidatorNeuron(BaseNeuron):
@@ -356,6 +357,7 @@ class BaseValidatorNeuron(BaseNeuron):
 
         #first, find unavailable uids:
         unavailable_uids = [i for i in range(self.metagraph.n) if not check_uid_availability(self.metagraph,i,self.config.neuron.vpermit_tao_limit)]
+        bt.logging.info(f"Found Unavailable UIDS: {unavailable_uids}")
 
         vl = ValidatorLib()
         updated_scores, updated_ema_scores = vl.update_scores(rewards, uids, self.ema_scores, self.scores, self.config.neuron.moving_average_alpha, self.device, self.metagraph.n, self.nonlinear_power, unavailable_uids)

--- a/conversationgenome/validator/ValidatorLib.py
+++ b/conversationgenome/validator/ValidatorLib.py
@@ -56,6 +56,7 @@ class ValidatorLib:
     def __init__(self):
         super(ValidatorLib, self).__init__()
         self.read_api_key()
+        
 
     def read_api_key(self):
         fail_message = "WARNING: You have not generated a ReadyAI Conversation Server API key. Starting on October 7th, 2024, you will no longer be able to request conversations from the ReadyAI Conversation server without an API Key. For instructions on how to generate your key, read the documentation in docs/generate-validator-api-key.md"
@@ -307,8 +308,24 @@ class ValidatorLib:
         await llml.test_tagging()
 
 
-    def update_scores(self, rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power):
-        
+    def update_scores(self, rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power, unavailable_uids=None):
+
+        #trend all unavailable uids towards 0
+        if unavailable_uids:
+            #find instances of unavailable_uids in uids and overwrite to reward of 0
+            for unavailable_uid in unavailable_uids:
+                if unavailable_uid in uids:
+                    print(f"found unavaiable uid: {unavailable_uid} in uids: {uids} with rewards: {rewards}")
+                    indices = [i for i, uid in enumerate(uids) if uid == unavailable_uid]
+                    print(f"Found indices: {indices}")
+                    if len(indices)>0:
+                        for index in indices:
+                            rewards[index]=0
+                    print(f"After overwrite, uids: {uids} with rewards: {rewards}")
+                else:
+                    uids = np.append(uids, unavailable_uid)
+                    rewards = np.append(rewards, 0)
+
         if isinstance(uids, np.ndarray):
             uids_array = np.copy(uids)
         else:

--- a/conversationgenome/validator/ValidatorLib.py
+++ b/conversationgenome/validator/ValidatorLib.py
@@ -315,13 +315,16 @@ class ValidatorLib:
             #find instances of unavailable_uids in uids and overwrite to reward of 0
             for unavailable_uid in unavailable_uids:
                 if unavailable_uid in uids:
-                    print(f"found unavaiable uid: {unavailable_uid} in uids: {uids} with rewards: {rewards}")
                     indices = [i for i, uid in enumerate(uids) if uid == unavailable_uid]
-                    print(f"Found indices: {indices}")
+                    if self.verbose:
+                        bt.logging.info(f"Found Unavaiable UID: {unavailable_uid} in uids: {uids} with rewards: {rewards}")
                     if len(indices)>0:
+                        if self.verbose:
+                            bt.logging.info(f"UID {unavailable_uid} Appears at indices: {indices} of the UIDs array")
                         for index in indices:
                             rewards[index]=0
-                    print(f"After overwrite, uids: {uids} with rewards: {rewards}")
+                    if self.verbose:
+                        bt.logging.info(f"After overwrite, uids: {uids} with rewards: {rewards}")
                 else:
                     uids = np.append(uids, unavailable_uid)
                     rewards = np.append(rewards, 0)
@@ -355,6 +358,12 @@ class ValidatorLib:
         # Update EMA scores
         alpha: float = moving_average_alpha
         ema_scores = alpha * scattered_rewards + (1 - alpha) * ema_scores
+
+        #correct asymptotic ema_score behavior for unavailable UIDs
+        if unavailable_uids:
+            for unavailable_uid in unavailable_uids:
+                if ema_scores[unavailable_uid] < 1e-20:
+                    ema_scores[unavailable_uid] = 0
         
         if self.verbose:
             bt.logging.debug(f"Updated moving avg scores: {ema_scores}")

--- a/tests/test_outlier_miner.py
+++ b/tests/test_outlier_miner.py
@@ -1,0 +1,78 @@
+import pytest
+import random
+import unittest
+import torch
+import numpy as np
+
+from conversationgenome.ConfigLib import c
+from conversationgenome.utils.Utils import Utils
+#
+from conversationgenome.validator.ValidatorLib import ValidatorLib
+from typing import List
+
+verbose = True
+
+bt = None
+try:
+    import bittensor as bt
+except:
+    if verbose:
+        print("bittensor not installed")
+    bt = MockBt()
+
+class TemplateEmaTestCase(unittest.TestCase):
+    verbose = True
+    vl= None
+
+    def setUp(self):
+        self.vl=ValidatorLib()
+        self.vl.verbose=False
+        pass
+
+    def test_great_score_variation(self):
+        iterations = 10000
+        unavailable_uids = [0,9]
+        stop_points = [round(iterations * 0.1), round(iterations * 0.5),round(iterations * 0.75)]
+        print(f"iterations: {iterations}")
+        print(f"stop points: {stop_points}")
+        moving_average_alpha = 0.1
+        device = "cuda"
+        neurons = 5
+        nonlinear_power = 3
+        i=0
+        scores = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+        ema_scores = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+        while i <= iterations:
+            uids = []
+            rewards = []
+            if i in stop_points:
+                stop_point = stop_points.index(i) + 1
+                print(f"stop point {stop_point} iteration: {i}")
+                print(f"EMA SCORES: {ema_scores}")
+                print(f"SCORES: {scores}")
+                print("\n")
+                if stop_point == 1:
+                    print("------UPDATING UID 0--------\n")
+                    # Hardcode UID 0 reward to be 0.75, randomize the other two for this update
+                    uids.append(0)
+                    uids.extend(random.sample(range(1, 9), 2))
+                    rewards.append(0.75)
+                    rewards.extend([random.uniform(0.35, 0.55) for _ in range(2)])
+                else:
+                    i+=1
+                    continue
+            else:
+                uids = random.sample(range(1, 9), 3)
+                rewards = np.array([random.uniform(0.35, 0.55) for _ in range(3)], dtype=np.float32)
+            
+            #update without fix
+            #scores, ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power)
+
+            #update with fix
+            scores, ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power, unavailable_uids)
+
+            i+=1
+
+        print(f"Completed iterations")
+        print(f"EMA SCORES: {ema_scores}")
+        print(f"SCORES: {scores}")

--- a/tests/test_outlier_miner.py
+++ b/tests/test_outlier_miner.py
@@ -20,59 +20,122 @@ except:
         print("bittensor not installed")
     bt = MockBt()
 
+
+def print_stats(scores, ema_scores, unavailable_uids=None, iteration=-100, stop_point= ""):
+    print("\n")
+    print(f"\033[92m\tstop point: {stop_point} iteration: {iteration}\033[0m")
+    print(f"\tEMA SCORES: \n\t{ema_scores}")
+    print(f"\tSCORES: \n\t{scores}")
+    for unavailable_uid in unavailable_uids:
+        print(f"\033[91m\tUnavailable UID {unavailable_uid} - Score: {scores[unavailable_uid]}, EMA Score: {ema_scores[unavailable_uid]}\033[0m")
+
 class TemplateEmaTestCase(unittest.TestCase):
     verbose = True
     vl= None
 
     def setUp(self):
         self.vl=ValidatorLib()
-        self.vl.verbose=False
+        self.vl.verbose=True
         pass
 
-    def test_great_score_variation(self):
+    def test_bug_and_fix(self):
         iterations = 10000
         unavailable_uids = [0,9]
         stop_points = [round(iterations * 0.1), round(iterations * 0.5),round(iterations * 0.75)]
-        print(f"iterations: {iterations}")
-        print(f"stop points: {stop_points}")
+        moving_average_alpha = 0.1
+        device = "cuda"
+        neurons = 5
+        nonlinear_power = 3
+
+        #iterate once without fix to show problem persisting
+        use_fix = False
+        j=0
+        print("\n---------------")
+        print("\033[94mTesting Bug Introduction and Fix\033[0m")
+        print(f"\033[94miterations: {iterations}\033[0m")
+        print(f"\033[94mstop points: {stop_points}\033[0m")
+        print(f"\033[94mUnavailable UIDs: {unavailable_uids}\033[0m")
+        while j<2:
+            print(f"\033[94mRunning {iterations} Iterations with use_fix == {use_fix}\033[0m")
+            i=0
+            scores = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+            ema_scores = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+            print_stats(scores, ema_scores, unavailable_uids, 0, "start")
+            while i <= iterations:
+                uids = []
+                rewards = []
+                if i in stop_points:
+                    stop_point = stop_points.index(i) + 1
+                    print_stats(scores, ema_scores, unavailable_uids, i, str(stop_point))
+                    if stop_point == 1:
+                        print("\n\n\tINTRODUCING BUG - UPDATING UID 0\n")
+                        # Hardcode UID 0 reward to be 0.75, randomize the other two for this update
+                        uids.append(0)
+                        uids.extend(random.sample(range(1, 9), 2))
+                        rewards.append(0.75)
+                        rewards.extend([random.uniform(0.35, 0.55) for _ in range(2)])
+                    else:
+                        i+=1
+                        continue
+                else:
+                    uids = random.sample(range(1, 9), 3)
+                    rewards = np.array([random.uniform(0.35, 0.55) for _ in range(3)], dtype=np.float32)
+
+                if use_fix:
+                    #update with fix
+                    scores, ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power, unavailable_uids)
+                else:
+                    #update without fix
+                    scores, ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power)
+
+                i+=1
+
+            print(f"Completed iterations with use_fix == {use_fix}")
+            print_stats(scores, ema_scores, unavailable_uids, iterations, "end")
+            #update use_fix to use the fix next time through
+            use_fix = True
+            j+=1
+            print("\n")
+
+
+    def test_preexisting_bug(self):
+        print(f"\n\n")
+        print("---------------")
+        print("\033[94mTesting Pre-existing bug\033[0m")
+        iterations = 1000
+        unavailable_uids = [0,9]
+        stop_points = [round(iterations * 0.1), round(iterations * 0.5),round(iterations * 0.75)]
         moving_average_alpha = 0.1
         device = "cuda"
         neurons = 5
         nonlinear_power = 3
         i=0
-        scores = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
-        ema_scores = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+        scores = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+        ema_scores = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+
+        print(f"\033[94miterations: {iterations}\033[0m")
+        print(f"\033[94mstop points: {stop_points}\033[0m")
+        print(f"\033[94mUnavailable UIDs: {unavailable_uids}\033[0m")
+        print_stats(scores, ema_scores, unavailable_uids, 0, "start")
+
         while i <= iterations:
             uids = []
             rewards = []
             if i in stop_points:
                 stop_point = stop_points.index(i) + 1
-                print(f"stop point {stop_point} iteration: {i}")
-                print(f"EMA SCORES: {ema_scores}")
-                print(f"SCORES: {scores}")
+                print_stats(scores, ema_scores, unavailable_uids, i, str(stop_point))
                 print("\n")
-                if stop_point == 1:
-                    print("------UPDATING UID 0--------\n")
-                    # Hardcode UID 0 reward to be 0.75, randomize the other two for this update
-                    uids.append(0)
-                    uids.extend(random.sample(range(1, 9), 2))
-                    rewards.append(0.75)
-                    rewards.extend([random.uniform(0.35, 0.55) for _ in range(2)])
-                else:
-                    i+=1
-                    continue
+                i+=1
+                continue
             else:
                 uids = random.sample(range(1, 9), 3)
                 rewards = np.array([random.uniform(0.35, 0.55) for _ in range(3)], dtype=np.float32)
-            
-            #update without fix
-            #scores, ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power)
 
-            #update with fix
             scores, ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power, unavailable_uids)
 
             i+=1
 
         print(f"Completed iterations")
-        print(f"EMA SCORES: {ema_scores}")
-        print(f"SCORES: {scores}")
+        print_stats(scores, ema_scores, unavailable_uids, iterations, "end")
+        for unavailable_uid in unavailable_uids:
+            print(f"Unavailable UID {unavailable_uid} - Score: {scores[unavailable_uid]}, EMA Score: {ema_scores[unavailable_uid]}")


### PR DESCRIPTION
How it works:

1. When we update scores, we obtain an array of currently unavailable uids in base/validator.py
2. We append the uid to the uids array and a reward of 0 to the rewards array
3. We scatter these rewards to the UIDS in the ema_scores calculation, creating a walkdown effect of any unavailable UIDs that currently have incentive
4. After ema_scores are calculated, we check if any of the unavailable_uids are < 1e-20. If they are we set them to 0 to clip asymptotic decay.