### PR TITLE
Moved is_validator to fix error when not a validator

### DIFF
--- a/scripts/get_validator_api_key.py
+++ b/scripts/get_validator_api_key.py
@@ -56,6 +56,7 @@ class ReadyAiApiLib():
 
     def get_validator_info(self, ss58_coldkey=None, ss58_hotkey=None, netuid=1, verbose=False):
         subnet = bt.metagraph(netuid, network=self.network)
+        is_validator = False
         if ss58_coldkey and not ss58_coldkey in subnet.coldkeys:
             print(f"{RED}Coldkey {ss58_coldkey} not registered on subnet. Aborting.{COLOR_END}")
             if self.verbose or verbose:
@@ -67,7 +68,6 @@ class ReadyAiApiLib():
             total_stake = 0.0
             stake = 0.0
             max_stake = 0.0
-            is_validator = False
             for idx, ck in enumerate(subnet.coldkeys):
                 if ss58_coldkey == ck:
                     #self.list_wallets_properties(subnet, uid=my_uid, tensor_len=len(subnet.coldkeys))


### PR DESCRIPTION
Calling the script without being a validator threw an `UnboundLocalError` because a variable was referenced before it was assigned:
![image](https://github.com/user-attachments/assets/2fe19daa-fe0f-44c1-9393-7c18c8520e55)

Moving it above the if ensures it can be reassigned and/or used properly afterwards.

The fix works:
![image](https://github.com/user-attachments/assets/9215dc8b-0909-4554-8ce4-e628e3b80c69)