### PR TITLE
Fix `miner.py` typo

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -149,13 +149,13 @@ class Miner(BaseMinerNeuron):
         caller_uid = self.metagraph.hotkeys.index(
             synapse.dendrite.hotkey
         )  # Get the caller index.
-        prirority = float(
+        priority = float(
             self.metagraph.S[caller_uid]
         )  # Return the stake as the priority.
         bt.logging.trace(
-            f"Prioritizing {synapse.dendrite.hotkey} with value: {prirority}"
+            f"Priority {synapse.dendrite.hotkey} with value: {priority}"
         )
-        return prirority
+        return priority
 
 
 # This is the main function, which runs the miner.


### PR DESCRIPTION
Small typo. Prirority = priority