### PR TITLE
[Feature-426] - Reduce alpha value in EMA when the score is 0 to dampen the impact

### DIFF
--- a/conversationgenome/__init__.py
+++ b/conversationgenome/__init__.py
@@ -15,7 +15,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "2.11.45"
+__version__ = "2.11.46"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/conversationgenome/__init__.py
+++ b/conversationgenome/__init__.py
@@ -15,7 +15,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "2.10.45"
+__version__ = "2.11.45"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/conversationgenome/validator/ValidatorLib.py
+++ b/conversationgenome/validator/ValidatorLib.py
@@ -355,9 +355,15 @@ class ValidatorLib:
 
         bt.logging.debug(f"Scattered rewards: {rewards}")
 
+        # Dampening factor for scattered rewards equal to 0 
+        default_alpha = moving_average_alpha    
+        low_alpha = moving_average_alpha / 2
+
+        # Vectorized alpha assignment, if the miner reward is 0, use low_alpha, otherwise use default_alpha 
+        alphas = np.where(scattered_rewards == 0, low_alpha, default_alpha)
+
         # Update EMA scores
-        alpha: float = moving_average_alpha
-        ema_scores = alpha * scattered_rewards + (1 - alpha) * ema_scores
+        ema_scores = alphas * scattered_rewards + (1 - alphas) * ema_scores
 
         if self.verbose:
             bt.logging.debug(f"Updated moving avg scores: {ema_scores}")
@@ -384,7 +390,6 @@ class ValidatorLib:
             bt.logging.debug(f"Updated final scores: {scores}")
 
         return scores, ema_scores
-
 
     async def prompt_call_csv(self, convoXmlStr=None, participants=None, override_prompt=None):
         llml = LlmLib()

--- a/conversationgenome/validator/ValidatorLib.py
+++ b/conversationgenome/validator/ValidatorLib.py
@@ -356,14 +356,16 @@ class ValidatorLib:
         bt.logging.debug(f"Scattered rewards: {rewards}")
 
         # Dampening factor for scattered rewards equal to 0 
-        default_alpha = moving_average_alpha    
-        low_alpha = moving_average_alpha / 2
-
-        # Vectorized alpha assignment, if the miner reward is 0, use low_alpha, otherwise use default_alpha 
-        alphas = np.where(scattered_rewards == 0, low_alpha, default_alpha)
+        default_alpha: float = moving_average_alpha    
+        low_alpha: float = moving_average_alpha / 2
 
         # Update EMA scores
-        ema_scores = alphas * scattered_rewards + (1 - alphas) * ema_scores
+        # if the miner reward is 0, use low_alpha, otherwise use default_alpha 
+        ema_scores = np.where(
+            scattered_rewards == 0,
+            low_alpha * scattered_rewards + (1 - low_alpha) * ema_scores,
+            default_alpha * scattered_rewards + (1 - default_alpha) * ema_scores
+        )
 
         if self.verbose:
             bt.logging.debug(f"Updated moving avg scores: {ema_scores}")

--- a/conversationgenome/validator/ValidatorLib.py
+++ b/conversationgenome/validator/ValidatorLib.py
@@ -363,7 +363,7 @@ class ValidatorLib:
         # if the miner reward is 0, use low_alpha, otherwise use default_alpha 
         ema_scores = np.where(
             scattered_rewards == 0,
-            low_alpha * scattered_rewards + (1 - low_alpha) * ema_scores,
+            (1 - low_alpha) * ema_scores,
             default_alpha * scattered_rewards + (1 - default_alpha) * ema_scores
         )
 

--- a/tests/test_dampening.py
+++ b/tests/test_dampening.py
@@ -1,0 +1,47 @@
+import unittest
+from typing import List
+
+import numpy as np
+import pytest
+
+from conversationgenome.mock import MockBt
+from conversationgenome.validator.ValidatorLib import ValidatorLib
+
+verbose = True
+bt = None
+
+try:
+    import bittensor as bt
+except:
+    if verbose:
+        print("bittensor not installed")
+    bt = MockBt()
+
+
+class DampeningTestCase(unittest.TestCase):
+    verbose = True
+    vl = None
+
+    def setUp(self):
+        self.vl = ValidatorLib()
+        self.vl.verbose = False
+        pass
+
+    def test_given_uids_with_previous_scores_when_they_score_0_then_they_are_dampened(self):
+        uids: List[int] = [1, 2, 3]
+        rewards = np.array([0.0, 0.2, 0.0], dtype=np.float32)
+        ema_scores = np.array([0.1, 0.2, 0.3, 0.4, 0.5], dtype=np.float32)
+        scores = np.array([0.004455, 0.035550, 0.120000, 0.284445, 0.555550], dtype=np.float32)
+        moving_average_alpha = 0.1
+        device = "cuda"
+        neurons = 5
+        nonlinear_power = 3
+ 
+        scores, updated_ema_scores = self.vl.update_scores(rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power)
+
+        assert updated_ema_scores[0] == pytest.approx(ema_scores[0]) #  No change, same score
+        assert updated_ema_scores[1] == pytest.approx(moving_average_alpha / 2 * rewards[0] + (1 - moving_average_alpha / 2) * ema_scores[1], abs=1e-2) #  Received a score of 0, so the alpha should be lower
+        assert updated_ema_scores[2] == pytest.approx(moving_average_alpha * rewards[1] + (1 - moving_average_alpha) * ema_scores[2], abs=1e-2) #  Regular alpha is applied cause the miner scored
+        assert updated_ema_scores[3] == pytest.approx(moving_average_alpha / 2 * rewards[2] + (1 - moving_average_alpha / 2) * ema_scores[3], abs=1e-2) #  Received a score of 0, so the alpha should be lower
+        assert updated_ema_scores[4] == pytest.approx(ema_scores[4]) #  No change, same score
+        

--- a/tests/test_ema.py
+++ b/tests/test_ema.py
@@ -5,6 +5,7 @@ import torch
 import numpy as np
 
 from conversationgenome.ConfigLib import c
+from conversationgenome.mock import MockBt
 from conversationgenome.utils.Utils import Utils
 #
 from conversationgenome.validator.ValidatorLib import ValidatorLib


### PR DESCRIPTION
This update improves the robustness of the EMA (Exponential Moving Average) score update by introducing adaptive alpha dampening.

- When a miner's reward is exactly 0, we now reduce the alpha by half from the default (0.1) to a smaller value (0.05).
- This adjustment dampens the impact of zero rewards, preventing sudden drops while still allowing the score to decrease gradually over time.
- For non-zero rewards, the default alpha is used as before to ensure normal responsiveness.

This change makes the EMA more stable and less sensitive to occasional zero rewards without ignoring them entirely. It will also reduce the variance in scoring.