### PR TITLE
Add safety check to `get_clean_tag_set`

### DIFF
--- a/conversationgenome/__init__.py
+++ b/conversationgenome/__init__.py
@@ -15,7 +15,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "2.12.47"
+__version__ = "2.13.48"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/conversationgenome/utils/Utils.py
+++ b/conversationgenome/utils/Utils.py
@@ -256,13 +256,19 @@ class Utils:
 
     @staticmethod
     def get_clean_tag_set(tags):
-        cleanTags = set()
-        for tag in tags:
-            safeTag = Utils.get_safe_tag(tag)
-            #print("len(safeTag)", len(safeTag), "----", safeTag)
-            if(len(safeTag) < 3 or len(safeTag) > 64):
-                continue
-            cleanTags.add(safeTag)
-        return list(cleanTags)
+        try:
+            cleanTags = set()
+
+            for tag in tags:
+                safeTag = Utils.get_safe_tag(tag)
+
+                if(len(safeTag) < 3 or len(safeTag) > 64):
+                    continue
+
+                cleanTags.add(safeTag)
+
+            return list(cleanTags)
+        except Exception as e:
+            return []
 
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -257,7 +257,15 @@ class Validator(BaseValidatorNeuron):
                     miner_result['tags'] = await vl.validate_tag_set(miner_result['original_tags'])
 
                     miner_result['vectors'] = await vl.get_vector_embeddings_set(miner_result['tags'])
-                    bt.logging.debug(f"GOOD RESPONSE: hotkey: {response.axon.hotkey} from miner response idx: {response_idx} window idx: {window_idx}  tags: {len(miner_result['tags'])} vector count: {len(miner_result['vectors'])} original tags: {len(miner_result['original_tags'])}")
+
+                    bt.logging.debug(
+                        f"GOOD RESPONSE: hotkey: {getattr(response.axon, 'hotkey', 'N/A')} "
+                        f"from miner response idx: {response_idx} window idx: {window_idx} "
+                        f"tags: {len(miner_result.get('tags', [])) if isinstance(miner_result.get('tags'), (list, dict)) else 0} "
+                        f"vector count: {len(miner_result.get('vectors', [])) if isinstance(miner_result.get('vectors'), (list, dict)) else 0} "
+                        f"original tags: {len(miner_result.get('original_tags', [])) if isinstance(miner_result.get('original_tags'), (list, dict)) else 0}"
+                    )
+
                     if response.axon.hotkey in hot_key_watchlist:
                         print(f"!!!!!!!!!!! GOOD WATCH: {response.axon.hotkey} !!!!!!!!!!!!!")
                     log_path = c.get('env', 'SCORING_DEBUG_LOG')


### PR DESCRIPTION
Adds a simple try/except around the tag cleaning logic to handle unexpected input more gracefully. This helps ensure the function remains robust without introducing any behaviour changes for valid input.