### PR TITLE
Fix: Use Conversation Direct Attributes

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -82,9 +82,9 @@ class Validator(BaseValidatorNeuron):
                 if not full_conversation:
                     continue
 
-                conversation_guid = str(Utils.get(full_conversation, "guid"))
+                conversation_guid = full_conversation.guid
                 bufferedConvos[conversation_guid] = full_conversation
-                participants = Utils.get(full_conversation, "participants")
+                participants = full_conversation.participants
                 indexed_windows = full_conversation.indexed_windows 
                 # Large number of windows were adversely impacting weight sync time, so limit to windows subset until local cache is ready.
 
@@ -123,6 +123,10 @@ class Validator(BaseValidatorNeuron):
                 batch_num = piece['batch_num']
                 full_conversation = bufferedConvos[conversation_guid]
 
+                if not conversation_guid:
+                    bt.logging.error("No conversation GUID found.")
+                    return
+                    
                 if not "metadata" in full_conversation:
                     if test_mode:
                         print(f"No metadata cached for {conversation_guid}. Processing metadata...")


### PR DESCRIPTION
This PR gets the attributes of the conversation directly and adds a failsafe.

There was a problem where the conversation_guid was `None`, creating a problem with the buffering of the conversations. This update fixes it.