### PR TITLE
Feat - Add user requested tasks

### DIFF
--- a/conversationgenome/task_bundle/ConversationTaggingTaskBundle.py
+++ b/conversationgenome/task_bundle/ConversationTaggingTaskBundle.py
@@ -60,13 +60,21 @@ class ConversationTaggingTaskBundle(TaskBundle):
     _QUALITY_THRESHOLD = Utils._int(c.get('env', 'CONVO_QUALITY_THRESHOLD', 5))
 
     def is_ready(self) -> bool:
-        if self.input.metadata is not None and self.input.data.indexed_windows is not None and self._check_conversation_quality():
+        if self.input.metadata is None or self.input.data.indexed_windows is None:
+            return False
+        if self.is_user_request:
             return True
-        return False
+        return self._check_conversation_quality()
 
     async def setup(self) -> None:
         self.input.trim_input()
         self._split_conversation_in_windows()
+
+        if self.is_user_request:
+            bt.logging.info("User-requested bundle: bypassing min-window and quality checks.")
+            await self._generate_metadata()
+            return
+
         self._enforce_minimum_convo_windows()
         await self._get_conversation_quality()
         # Only generate metadata and make bundle ready for conversations that pass quality threshold

--- a/conversationgenome/task_bundle/ConversationTaggingTaskBundle.py
+++ b/conversationgenome/task_bundle/ConversationTaggingTaskBundle.py
@@ -71,7 +71,6 @@ class ConversationTaggingTaskBundle(TaskBundle):
         self._split_conversation_in_windows()
 
         if self.is_user_request:
-            bt.logging.info("User-requested bundle: bypassing min-window and quality checks.")
             await self._generate_metadata()
             return
 

--- a/conversationgenome/task_bundle/TaskBundle.py
+++ b/conversationgenome/task_bundle/TaskBundle.py
@@ -27,6 +27,7 @@ class TaskBundle(BaseModel, ABC):
     example_output: Optional[ExampleOutputUnion] = None
     errors: List[Any] = Field(default_factory=list)
     warnings: List[Any] = Field(default_factory=list)
+    is_user_request: bool = False
 
     @abstractmethod
     def is_ready(self) -> bool:

--- a/conversationgenome/task_bundle/WebpageMetadataGenerationTaskBundle.py
+++ b/conversationgenome/task_bundle/WebpageMetadataGenerationTaskBundle.py
@@ -74,9 +74,7 @@ class WebpageMetadataGenerationTaskBundle(TaskBundle):
     async def setup(self) -> None:
         self.input.trim_input()
         self._split_conversation_in_windows()
-        if self.is_user_request:
-            bt.logging.info("User-requested bundle: bypassing min-window check.")
-        else:
+        if not self.is_user_request:
             self._enforce_minimum_convo_windows()
         await self._generate_metadata()
 

--- a/conversationgenome/task_bundle/WebpageMetadataGenerationTaskBundle.py
+++ b/conversationgenome/task_bundle/WebpageMetadataGenerationTaskBundle.py
@@ -74,7 +74,10 @@ class WebpageMetadataGenerationTaskBundle(TaskBundle):
     async def setup(self) -> None:
         self.input.trim_input()
         self._split_conversation_in_windows()
-        self._enforce_minimum_convo_windows()
+        if self.is_user_request:
+            bt.logging.info("User-requested bundle: bypassing min-window check.")
+        else:
+            self._enforce_minimum_convo_windows()
         await self._generate_metadata()
 
     def to_mining_tasks(self, number_of_tasks_per_bundle: int) -> List[Task]:

--- a/tests/unit/test_ConversationTaggingTaskBundle.py
+++ b/tests/unit/test_ConversationTaggingTaskBundle.py
@@ -60,6 +60,47 @@ def test_is_ready_true_when_metadata_and_windows(sample_input):
     assert bundle.is_ready()
 
 
+def test_is_ready_true_for_user_request_without_quality():
+    bundle = DummyData.conversation_tagging_task_bundle()
+    bundle.is_user_request = True
+    bundle.input.quality_score = None
+    bundle.input.metadata = ConversationMetadata(participantProfiles=["Alice", "Bob"], tags=[], vectors={})
+    bundle.input.data.indexed_windows = [(0, [(0, "Hello"), (1, "Hi")])]
+    assert bundle.is_ready()
+
+
+def test_is_ready_true_for_user_request_below_quality_threshold():
+    bundle = DummyData.conversation_tagging_task_bundle()
+    bundle.is_user_request = True
+    bundle.input.quality_score = 1
+    bundle.input.metadata = ConversationMetadata(participantProfiles=["Alice", "Bob"], tags=[], vectors={})
+    bundle.input.data.indexed_windows = [(0, [(0, "Hello"), (1, "Hi")])]
+    assert bundle.is_ready()
+
+
+def test_is_ready_false_for_user_request_missing_metadata():
+    bundle = DummyData.conversation_tagging_task_bundle()
+    bundle.is_user_request = True
+    bundle.input.metadata = None
+    bundle.input.data.indexed_windows = [(0, [(0, "Hello"), (1, "Hi")])]
+    assert not bundle.is_ready()
+
+
+@pytest.mark.asyncio
+async def test_setup_user_request_skips_quality_and_min_windows():
+    bundle = DummyData.conversation_tagging_task_bundle()
+    bundle.is_user_request = True
+    with patch.object(bundle, "_split_conversation_in_windows") as mock_split, \
+         patch.object(bundle, "_enforce_minimum_convo_windows") as mock_enforce, \
+         patch.object(bundle, "_get_conversation_quality", AsyncMock()) as mock_quality, \
+         patch.object(bundle, "_generate_metadata", AsyncMock()) as mock_generate:
+        await bundle.setup()
+        mock_split.assert_called_once()
+        mock_enforce.assert_not_called()
+        mock_quality.assert_not_called()
+        mock_generate.assert_called_once()
+
+
 def test_split_conversation_in_windows_sets_indexed_windows(sample_input):
     bundle = DummyData.conversation_tagging_task_bundle()
     with patch("conversationgenome.task_bundle.ConversationTaggingTaskBundle.c.get", side_effect=lambda *a, **k: 2):

--- a/tests/unit/test_WebpageMetadataGenerationTaskBundle.py
+++ b/tests/unit/test_WebpageMetadataGenerationTaskBundle.py
@@ -27,11 +27,26 @@ async def test_setup_calls_trim_input_and_split_and_generate():
     with patch.object(bundle, '_split_conversation_in_windows') as mock_split, \
          patch.object(bundle, '_enforce_minimum_convo_windows') as mock_enforce, \
          patch.object(bundle, '_generate_metadata') as mock_generate:
-        
+
         await bundle.setup()
-        
+
         mock_split.assert_called_once()
         mock_enforce.assert_called_once()
+        mock_generate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_user_request_skips_min_windows():
+    bundle = DummyData.webpage_metadata_generation_task_bundle()
+    bundle.is_user_request = True
+    with patch.object(bundle, '_split_conversation_in_windows') as mock_split, \
+         patch.object(bundle, '_enforce_minimum_convo_windows') as mock_enforce, \
+         patch.object(bundle, '_generate_metadata') as mock_generate:
+
+        await bundle.setup()
+
+        mock_split.assert_called_once()
+        mock_enforce.assert_not_called()
         mock_generate.assert_called_once()
 
 


### PR DESCRIPTION
Add new flag to better handle user-requested tasks.

Tasks submitted through our API do no go through the usual quality checks to insure that tags are returned.