### PR TITLE
Feat - Add encrypted endpoint commitment system to hide miner IPs from metagraph  

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,23 @@ If you are running on runpod, please read instructions [here](#Using-Runpod)
 
 To setup and run a validator with Docker, see instructions [here](#Running-a-Miner-or-a-Validator-with-Docker).
 
+### Encrypted Endpoint Commitments
+
+Miner IP addresses are encrypted on-chain so they are not visible in the metagraph. Validators need a private key to decrypt miner endpoints.
+
+**Testnet** — The testnet private key is included in `env.example`. Make sure it is set in your environment:
+
+```
+export COMMITMENT_PRIVATE_KEY=d0e8b84e89b085e0157dec62680987274eb1f136c7b6ac5bb7b2a21cce533294
+```
+
+**Mainnet** — The mainnet private key is distributed securely to validators. Do NOT commit it to any repository or share it publicly. Set it in your environment before starting the validator:
+
+```
+export COMMITMENT_PRIVATE_KEY=<provided securely>
+```
+
+### Running a Validator
 
 ```
 python3 -m neurons.validator --subtensor.network test --netuid 138 --wallet.name <wallet name> --wallet.hotkey <hotkey name> --logging.debug --axon.port <port>

--- a/conversationgenome/__init__.py
+++ b/conversationgenome/__init__.py
@@ -15,7 +15,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "2.30.66"
+__version__ = "2.31.67"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/conversationgenome/base/miner.py
+++ b/conversationgenome/base/miner.py
@@ -121,7 +121,8 @@ class BaseMinerNeuron(BaseNeuron):
                 bt.logging.info(f"Real endpoint: {real_ip}:{real_port} — will be encrypted in commitment.")
 
                 public_key_bytes = bytes.fromhex(commitment_pub_key_hex)
-                ciphertext = encrypt_endpoint(real_ip, real_port, public_key_bytes)
+                hotkey_ss58 = self.wallet.hotkey.ss58_address
+                ciphertext = encrypt_endpoint(real_ip, real_port, public_key_bytes, hotkey=hotkey_ss58)
                 success = publish_commitment(self.subtensor, self.wallet, self.config.netuid, ciphertext)
                 if success:
                     bt.logging.info(f"Encrypted endpoint commitment published successfully.")

--- a/conversationgenome/base/miner.py
+++ b/conversationgenome/base/miner.py
@@ -138,7 +138,7 @@ class BaseMinerNeuron(BaseNeuron):
 
         # Serve passes the axon information to the network + netuid we are hosting on.
         bt.logging.info(
-            f"Serving miner axon {self.axon} on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}"
+            f"Serving miner axon (external: {self.axon.external_ip}:{self.axon.external_port}) on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}"
         )
         self.axon.serve(netuid=self.config.netuid, subtensor=self.subtensor)
 

--- a/conversationgenome/base/miner.py
+++ b/conversationgenome/base/miner.py
@@ -15,6 +15,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+import os
 import time
 import torch
 import asyncio
@@ -103,6 +104,24 @@ class BaseMinerNeuron(BaseNeuron):
             f"Serving miner axon {self.axon} on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}"
         )
         self.axon.serve(netuid=self.config.netuid, subtensor=self.subtensor)
+
+        # Publish encrypted endpoint commitment if configured.
+        commitment_pub_key_hex = os.environ.get("COMMITMENT_PUBLIC_KEY", "").strip()
+        if commitment_pub_key_hex:
+            try:
+                from conversationgenome.commitment.commitment import encrypt_endpoint, publish_commitment
+
+                public_key_bytes = bytes.fromhex(commitment_pub_key_hex)
+                axon_ip = self.axon.external_ip
+                axon_port = self.axon.external_port
+                ciphertext = encrypt_endpoint(axon_ip, axon_port, public_key_bytes)
+                success = publish_commitment(self.subtensor, self.wallet, self.config.netuid, ciphertext)
+                if success:
+                    bt.logging.info(f"Encrypted endpoint commitment published successfully.")
+                else:
+                    bt.logging.warning(f"Encrypted endpoint commitment failed — will retry on next restart.")
+            except Exception as e:
+                bt.logging.error(f"Error publishing encrypted commitment: {e}")
 
         # Start  starts the miner's axon, making it active on the network.
         self.axon.start()

--- a/conversationgenome/base/miner.py
+++ b/conversationgenome/base/miner.py
@@ -120,10 +120,11 @@ class BaseMinerNeuron(BaseNeuron):
                 else:
                     bt.logging.warning(f"Encrypted endpoint commitment failed — will retry on next restart.")
 
-                # Serve dummy address to metagraph so real endpoint is not visible
-                self.axon.external_ip = "0.0.0.0"
+                # Serve blackhole address to metagraph so real endpoint is not visible
+                # 192.0.2.0/24 is TEST-NET-1 (RFC 5737), reserved and non-routable
+                self.axon.external_ip = "192.0.2.1"
                 self.axon.external_port = 1234
-                bt.logging.info(f"Serving dummy endpoint 0.0.0.0:1234 to metagraph.")
+                bt.logging.info(f"Serving dummy endpoint to metagraph.")
             except Exception as e:
                 bt.logging.error(f"Error publishing encrypted commitment: {e}")
 

--- a/conversationgenome/base/miner.py
+++ b/conversationgenome/base/miner.py
@@ -98,30 +98,40 @@ class BaseMinerNeuron(BaseNeuron):
         # Check that miner is registered on the network.
         self.sync()
 
-        # Serve passes the axon information to the network + netuid we are hosting on.
-        # This will auto-update if the axon port of external ip have changed.
-        bt.logging.info(
-            f"Serving miner axon {self.axon} on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}"
-        )
-        self.axon.serve(netuid=self.config.netuid, subtensor=self.subtensor)
-
         # Publish encrypted endpoint commitment if configured.
+        # When active, the real ip:port goes into the encrypted commitment only,
+        # and the metagraph gets a dummy address so the real endpoint stays hidden.
         commitment_pub_key_hex = os.environ.get("COMMITMENT_PUBLIC_KEY", "").strip()
         if commitment_pub_key_hex:
             try:
                 from conversationgenome.commitment.commitment import encrypt_endpoint, publish_commitment
 
+                # --axon.ip and --axon.port hold the user-specified values;
+                # external_ip/external_port may be auto-detected or None.
+                real_ip = self.axon.ip
+                real_port = self.axon.port
+                bt.logging.info(f"Real endpoint: {real_ip}:{real_port} — will be encrypted in commitment.")
+
                 public_key_bytes = bytes.fromhex(commitment_pub_key_hex)
-                axon_ip = self.axon.external_ip
-                axon_port = self.axon.external_port
-                ciphertext = encrypt_endpoint(axon_ip, axon_port, public_key_bytes)
+                ciphertext = encrypt_endpoint(real_ip, real_port, public_key_bytes)
                 success = publish_commitment(self.subtensor, self.wallet, self.config.netuid, ciphertext)
                 if success:
                     bt.logging.info(f"Encrypted endpoint commitment published successfully.")
                 else:
                     bt.logging.warning(f"Encrypted endpoint commitment failed — will retry on next restart.")
+
+                # Serve dummy address to metagraph so real endpoint is not visible
+                self.axon.external_ip = "0.0.0.0"
+                self.axon.external_port = 1234
+                bt.logging.info(f"Serving dummy endpoint 0.0.0.0:1234 to metagraph.")
             except Exception as e:
                 bt.logging.error(f"Error publishing encrypted commitment: {e}")
+
+        # Serve passes the axon information to the network + netuid we are hosting on.
+        bt.logging.info(
+            f"Serving miner axon {self.axon} on network: {self.config.subtensor.chain_endpoint} with netuid: {self.config.netuid}"
+        )
+        self.axon.serve(netuid=self.config.netuid, subtensor=self.subtensor)
 
         # Start  starts the miner's axon, making it active on the network.
         self.axon.start()

--- a/conversationgenome/base/miner.py
+++ b/conversationgenome/base/miner.py
@@ -101,7 +101,15 @@ class BaseMinerNeuron(BaseNeuron):
         # Publish encrypted endpoint commitment if configured.
         # When active, the real ip:port goes into the encrypted commitment only,
         # and the metagraph gets a dummy address so the real endpoint stays hidden.
-        commitment_pub_key_hex = os.environ.get("COMMITMENT_PUBLIC_KEY", "").strip()
+        # Shared public key for encrypting endpoint commitments.
+        # Mainnet (netuid 33) and testnet use different keypairs.
+        # Can be overridden via COMMITMENT_PUBLIC_KEY env var.
+        _COMMITMENT_PUBLIC_KEYS = {
+            33: "aadbfa93972378fbc1bd8e854bc6fb915bb57506f56c17f0531647a127a0bd69",  # mainnet
+            138: "2c068a9b7c3480225ab56888227218228d803208f26bfbd8c875a919467a7516",  # testnet
+        }
+        default_key = _COMMITMENT_PUBLIC_KEYS.get(self.config.netuid, "")
+        commitment_pub_key_hex = os.environ.get("COMMITMENT_PUBLIC_KEY", default_key).strip()
         if commitment_pub_key_hex:
             try:
                 from conversationgenome.commitment.commitment import encrypt_endpoint, publish_commitment

--- a/conversationgenome/base/validator.py
+++ b/conversationgenome/base/validator.py
@@ -66,14 +66,26 @@ class BaseValidatorNeuron(BaseNeuron):
 
         # Install a log filter to redact miner IP addresses from bittensor's
         # internal dendrite/axon logs (trace, debug, error messages).
-        _ip_port_re = re.compile(
-            r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}\b"
+        # Matches ip:port, ip:port/, ('ip', port), and bare IPs in URLs.
+        _ip_redact_patterns = re.compile(
+            r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d{1,5})?\b"
         )
 
         class _RedactIPFilter(logging.Filter):
             def filter(self, record):
                 if hasattr(record, "msg") and isinstance(record.msg, str):
-                    record.msg = _ip_port_re.sub("[REDACTED]", record.msg)
+                    record.msg = _ip_redact_patterns.sub("[REDACTED]", record.msg)
+                if hasattr(record, "args") and record.args:
+                    if isinstance(record.args, dict):
+                        record.args = {
+                            k: _ip_redact_patterns.sub("[REDACTED]", str(v)) if isinstance(v, str) else v
+                            for k, v in record.args.items()
+                        }
+                    elif isinstance(record.args, tuple):
+                        record.args = tuple(
+                            _ip_redact_patterns.sub("[REDACTED]", str(a)) if isinstance(a, str) else a
+                            for a in record.args
+                        )
                 return True
 
         for handler in logging.root.handlers:

--- a/conversationgenome/base/validator.py
+++ b/conversationgenome/base/validator.py
@@ -23,7 +23,7 @@ import datetime
 import os
 import threading
 from traceback import print_exception
-from typing import List
+from typing import Dict, List, Tuple
 
 import bittensor as bt
 import numpy as np
@@ -73,6 +73,9 @@ class BaseValidatorNeuron(BaseNeuron):
 
         # Burn rate -> burns 90% of the emissions.
         self.burn_rate = 0.9
+
+        # Committed endpoint cache: {hotkey_ss58: (ip, port)}
+        self.committed_endpoints: Dict[str, Tuple[str, int]] = {}
 
         # Init sync with the network. Updates the metagraph.
         self.sync()
@@ -319,6 +322,27 @@ class BaseValidatorNeuron(BaseNeuron):
         else:
             bt.logging.error(f"set_weights failed: {msg}")
 
+    def refresh_miner_endpoints(self):
+        """Read and decrypt encrypted endpoint commitments for all miners."""
+        private_key_hex = os.environ.get("COMMITMENT_PRIVATE_KEY", "").strip()
+        if not private_key_hex:
+            return
+
+        try:
+            from conversationgenome.commitment.commitment import read_all_commitments
+
+            private_key_bytes = bytes.fromhex(private_key_hex)
+            endpoints = read_all_commitments(
+                self.subtensor, self.config.netuid, self.metagraph.hotkeys, private_key_bytes
+            )
+            self.committed_endpoints = endpoints
+            bt.logging.info(f"Fetched commitments for {len(self.metagraph.hotkeys)} hotkeys, {len(endpoints)} decrypted successfully.")
+            for hotkey, (ip, port) in endpoints.items():
+                uid = self.metagraph.hotkeys.index(hotkey) if hotkey in self.metagraph.hotkeys else "?"
+                bt.logging.info(f"  Commitment: UID {uid} -> {ip}:{port}")
+        except Exception as e:
+            bt.logging.error(f"Error refreshing miner commitments: {e}")
+
     def resync_metagraph(self):
         """Resyncs the metagraph and updates the hotkeys and moving averages based on the new metagraph."""
         bt.logging.info("resync_metagraph()")
@@ -354,6 +378,9 @@ class BaseValidatorNeuron(BaseNeuron):
 
         # Update the hotkeys.
         self.hotkeys = copy.deepcopy(self.metagraph.hotkeys)
+
+        # Refresh encrypted endpoint commitments.
+        self.refresh_miner_endpoints()
 
     def update_scores(self, rewards: np.ndarray, uids: List[int]):
         """

--- a/conversationgenome/base/validator.py
+++ b/conversationgenome/base/validator.py
@@ -20,7 +20,9 @@ import argparse
 import asyncio
 import copy
 import datetime
+import logging
 import os
+import re
 import threading
 from traceback import print_exception
 from typing import Dict, List, Tuple
@@ -61,6 +63,21 @@ class BaseValidatorNeuron(BaseNeuron):
         else:
             self.dendrite = bt.dendrite(wallet=self.wallet)
         bt.logging.info(f"Dendrite: {self.dendrite}")
+
+        # Install a log filter to redact miner IP addresses from bittensor's
+        # internal dendrite/axon logs (trace, debug, error messages).
+        _ip_port_re = re.compile(
+            r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}\b"
+        )
+
+        class _RedactIPFilter(logging.Filter):
+            def filter(self, record):
+                if hasattr(record, "msg") and isinstance(record.msg, str):
+                    record.msg = _ip_port_re.sub("[REDACTED]", record.msg)
+                return True
+
+        for handler in logging.root.handlers:
+            handler.addFilter(_RedactIPFilter())
 
         # Set up initial scoring weights for validation
         bt.logging.info("Building validation weights.")
@@ -337,9 +354,9 @@ class BaseValidatorNeuron(BaseNeuron):
             )
             self.committed_endpoints = endpoints
             bt.logging.info(f"Fetched commitments for {len(self.metagraph.hotkeys)} hotkeys, {len(endpoints)} decrypted successfully.")
-            for hotkey, (ip, port) in endpoints.items():
+            for hotkey in endpoints:
                 uid = self.metagraph.hotkeys.index(hotkey) if hotkey in self.metagraph.hotkeys else "?"
-                bt.logging.info(f"  Commitment: UID {uid} -> {ip}:{port}")
+                bt.logging.info(f"  Commitment found for UID {uid}")
         except Exception as e:
             bt.logging.error(f"Error refreshing miner commitments: {e}")
 

--- a/conversationgenome/base/validator.py
+++ b/conversationgenome/base/validator.py
@@ -370,6 +370,10 @@ class BaseValidatorNeuron(BaseNeuron):
         # Sync the metagraph.
         self.metagraph.sync(subtensor=self.subtensor)
 
+        # Refresh encrypted endpoint commitments on every metagraph sync,
+        # regardless of whether axon info changed (commitments are independent).
+        self.refresh_miner_endpoints()
+
         # Check if the metagraph axon info has changed.
         if previous_metagraph.axons == self.metagraph.axons:
             return
@@ -395,9 +399,6 @@ class BaseValidatorNeuron(BaseNeuron):
 
         # Update the hotkeys.
         self.hotkeys = copy.deepcopy(self.metagraph.hotkeys)
-
-        # Refresh encrypted endpoint commitments.
-        self.refresh_miner_endpoints()
 
     def update_scores(self, rewards: np.ndarray, uids: List[int]):
         """

--- a/conversationgenome/base/validator.py
+++ b/conversationgenome/base/validator.py
@@ -397,6 +397,15 @@ class BaseValidatorNeuron(BaseNeuron):
         # Sync the metagraph.
         self.metagraph.sync(subtensor=self.subtensor)
 
+        # Clean stale entries from commitment caches for hotkeys no longer in metagraph.
+        current_hotkeys = set(self.metagraph.hotkeys)
+        stale_keys = [hk for hk in self.committed_endpoints if hk not in current_hotkeys]
+        for hk in stale_keys:
+            del self.committed_endpoints[hk]
+            self._commitment_cache.pop(hk, None)
+        if stale_keys:
+            bt.logging.info(f"Cleaned {len(stale_keys)} stale commitment cache entries.")
+
         # Refresh encrypted endpoint commitments on every metagraph sync,
         # regardless of whether axon info changed (commitments are independent).
         self.refresh_miner_endpoints()

--- a/conversationgenome/base/validator.py
+++ b/conversationgenome/base/validator.py
@@ -109,6 +109,9 @@ class BaseValidatorNeuron(BaseNeuron):
 
         # Committed endpoint cache: {hotkey_ss58: (ip, port)}
         self.committed_endpoints: Dict[str, Tuple[str, int]] = {}
+        # Block-aware cache: {hotkey_ss58: (block, ip, port)}
+        self._commitment_cache: dict = {}
+        self._last_commitment_refresh: float = 0.0
 
         # Init sync with the network. Updates the metagraph.
         self.sync()
@@ -361,15 +364,23 @@ class BaseValidatorNeuron(BaseNeuron):
         if not private_key_hex:
             return
 
+        # Skip if we refreshed less than 5 minutes ago
+        import time as _time
+        now = _time.time()
+        if now - self._last_commitment_refresh < 300:
+            bt.logging.info(f"Skipping commitment refresh — last refresh was {int(now - self._last_commitment_refresh)}s ago.")
+            return
+        self._last_commitment_refresh = now
+
         try:
             from conversationgenome.commitment.commitment import read_all_commitments
 
             private_key_bytes = bytes.fromhex(private_key_hex)
-            endpoints = read_all_commitments(
-                self.subtensor, self.config.netuid, self.metagraph.hotkeys, private_key_bytes
+            endpoints, self._commitment_cache = read_all_commitments(
+                self.subtensor, self.config.netuid, self.metagraph.hotkeys, private_key_bytes,
+                cache=self._commitment_cache,
             )
             self.committed_endpoints = endpoints
-            bt.logging.info(f"Fetched commitments for {len(self.metagraph.hotkeys)} hotkeys, {len(endpoints)} decrypted successfully.")
             for hotkey in endpoints:
                 uid = self.metagraph.hotkeys.index(hotkey) if hotkey in self.metagraph.hotkeys else "?"
                 bt.logging.info(f"  Commitment found for UID {uid}")

--- a/conversationgenome/base/validator.py
+++ b/conversationgenome/base/validator.py
@@ -73,8 +73,12 @@ class BaseValidatorNeuron(BaseNeuron):
 
         class _RedactIPFilter(logging.Filter):
             def filter(self, record):
-                if hasattr(record, "msg") and isinstance(record.msg, str):
-                    record.msg = _ip_redact_patterns.sub("[REDACTED]", record.msg)
+                msg = getattr(record, "msg", "")
+                if isinstance(msg, str):
+                    # Drop dendrite connection error logs entirely — they leak IPs
+                    if "Can not write request body" in msg or "Cannot connect to host" in msg:
+                        return False
+                    record.msg = _ip_redact_patterns.sub("[REDACTED]", msg)
                 if hasattr(record, "args") and record.args:
                     if isinstance(record.args, dict):
                         record.args = {

--- a/conversationgenome/commitment/commitment.py
+++ b/conversationgenome/commitment/commitment.py
@@ -1,0 +1,76 @@
+from typing import Optional
+
+import bittensor as bt
+from nacl.public import PrivateKey, PublicKey, SealedBox
+
+
+def encrypt_endpoint(ip: str, port: int, public_key_bytes: bytes) -> bytes:
+    """Encrypt an ip:port string using a NaCl sealed box."""
+    plaintext = f"{ip}:{port}".encode()
+    box = SealedBox(PublicKey(public_key_bytes))
+    return box.encrypt(plaintext)
+
+
+def decrypt_endpoint(ciphertext: bytes, private_key_bytes: bytes) -> tuple:
+    """Decrypt ciphertext to recover (ip, port)."""
+    box = SealedBox(PrivateKey(private_key_bytes))
+    plaintext = box.decrypt(ciphertext).decode()
+    ip, port_str = plaintext.rsplit(":", 1)
+    return ip, int(port_str)
+
+
+def publish_commitment(subtensor, wallet, netuid: int, ciphertext: bytes) -> bool:
+    """Publish encrypted endpoint ciphertext on-chain via publish_metadata."""
+    from bittensor.core.extrinsics.serving import publish_metadata
+
+    try:
+        publish_metadata(
+            subtensor=subtensor,
+            wallet=wallet,
+            netuid=netuid,
+            data_type=f"Raw{len(ciphertext)}",
+            data=ciphertext,
+            wait_for_inclusion=True,
+            wait_for_finalization=True,
+        )
+        return True
+    except Exception as e:
+        error_msg = str(e).lower()
+        if any(kw in error_msg for kw in ("rate", "cooldown", "limit")):
+            bt.logging.warning(f"Commitment rate-limited, will retry after cooldown: {e}")
+        else:
+            bt.logging.error(f"Failed to publish commitment: {e}")
+        return False
+
+
+def read_commitment(subtensor, netuid: int, hotkey_ss58: str) -> Optional[bytes]:
+    """Read a single miner's encrypted commitment from chain."""
+    from bittensor.core.extrinsics.serving import get_metadata
+
+    try:
+        metadata = get_metadata(subtensor, netuid, hotkey_ss58)
+        if metadata is None:
+            return None
+        commitment = metadata["info"]["fields"][0][0]
+        raw_key = next(iter(commitment.keys()))
+        return bytes(commitment[raw_key][0])
+    except Exception as e:
+        bt.logging.debug(f"Could not read commitment for {hotkey_ss58}: {e}")
+        return None
+
+
+def read_all_commitments(
+    subtensor, netuid: int, hotkeys: list, private_key_bytes: bytes
+) -> dict:
+    """Read and decrypt commitments for all hotkeys. Returns {hotkey: (ip, port)}."""
+    endpoints = {}
+    for hotkey in hotkeys:
+        ciphertext = read_commitment(subtensor, netuid, hotkey)
+        if ciphertext is None:
+            continue
+        try:
+            ip, port = decrypt_endpoint(ciphertext, private_key_bytes)
+            endpoints[hotkey] = (ip, port)
+        except Exception as e:
+            bt.logging.debug(f"Could not decrypt commitment for {hotkey}: {e}")
+    return endpoints

--- a/conversationgenome/commitment/commitment.py
+++ b/conversationgenome/commitment/commitment.py
@@ -1,21 +1,39 @@
 from typing import Optional
 
 import bittensor as bt
+import nacl.exceptions
 from nacl.public import PrivateKey, PublicKey, SealedBox
 
 
-def encrypt_endpoint(ip: str, port: int, public_key_bytes: bytes) -> bytes:
-    """Encrypt an ip:port string using a NaCl sealed box."""
-    plaintext = f"{ip}:{port}".encode()
+def encrypt_endpoint(ip: str, port: int, public_key_bytes: bytes, hotkey: str = "") -> bytes:
+    """Encrypt hotkey|ip:port using a NaCl sealed box.
+
+    The hotkey is embedded so the validator can verify the commitment
+    belongs to the miner that published it (prevents replay attacks).
+    """
+    plaintext = f"{hotkey}|{ip}:{port}".encode()
     box = SealedBox(PublicKey(public_key_bytes))
     return box.encrypt(plaintext)
 
 
-def decrypt_endpoint(ciphertext: bytes, private_key_bytes: bytes) -> tuple:
-    """Decrypt ciphertext to recover (ip, port)."""
+def decrypt_endpoint(ciphertext: bytes, private_key_bytes: bytes, expected_hotkey: str = "") -> tuple:
+    """Decrypt ciphertext to recover (ip, port).
+
+    If expected_hotkey is provided, verifies the embedded hotkey matches.
+    Raises ValueError on mismatch (commitment was copied from another miner).
+    """
     box = SealedBox(PrivateKey(private_key_bytes))
     plaintext = box.decrypt(ciphertext).decode()
-    ip, port_str = plaintext.rsplit(":", 1)
+
+    if "|" in plaintext:
+        hotkey_part, endpoint = plaintext.split("|", 1)
+        if expected_hotkey and hotkey_part != expected_hotkey:
+            raise ValueError(f"Commitment hotkey mismatch: expected {expected_hotkey[:8]}..., got {hotkey_part[:8]}...")
+    else:
+        # Backwards compatible with old format (ip:port without hotkey)
+        endpoint = plaintext
+
+    ip, port_str = endpoint.rsplit(":", 1)
     return ip, int(port_str)
 
 
@@ -129,10 +147,18 @@ def read_all_commitments(
             continue
 
         try:
-            ip, port = decrypt_endpoint(ciphertext, private_key_bytes)
+            ip, port = decrypt_endpoint(ciphertext, private_key_bytes, expected_hotkey=hotkey_str)
             new_cache[hotkey_str] = (block, ip, port)
             endpoints[hotkey_str] = (ip, port)
             found += 1
+        except ValueError as e:
+            # Hotkey mismatch — commitment was likely copied from another miner
+            bt.logging.warning(f"Rejected commitment for {hotkey_str}: {e}")
+        except nacl.exceptions.CryptoError:
+            # Wrong public key or corrupted/random data
+            bt.logging.debug(f"Could not decrypt commitment for {hotkey_str}: invalid ciphertext (wrong key or garbage data)")
+        except UnicodeDecodeError:
+            bt.logging.debug(f"Could not decrypt commitment for {hotkey_str}: decrypted bytes are not valid UTF-8")
         except Exception as e:
             bt.logging.debug(f"Could not decrypt commitment for {hotkey_str}: {e}")
 

--- a/conversationgenome/commitment/commitment.py
+++ b/conversationgenome/commitment/commitment.py
@@ -25,13 +25,12 @@ def decrypt_endpoint(ciphertext: bytes, private_key_bytes: bytes, expected_hotke
     box = SealedBox(PrivateKey(private_key_bytes))
     plaintext = box.decrypt(ciphertext).decode()
 
-    if "|" in plaintext:
-        hotkey_part, endpoint = plaintext.split("|", 1)
-        if expected_hotkey and hotkey_part != expected_hotkey:
-            raise ValueError(f"Commitment hotkey mismatch: expected {expected_hotkey[:8]}..., got {hotkey_part[:8]}...")
-    else:
-        # Backwards compatible with old format (ip:port without hotkey)
-        endpoint = plaintext
+    if "|" not in plaintext:
+        raise ValueError("Invalid commitment format: missing hotkey (old format no longer supported)")
+
+    hotkey_part, endpoint = plaintext.split("|", 1)
+    if expected_hotkey and hotkey_part != expected_hotkey:
+        raise ValueError(f"Commitment hotkey mismatch: expected {expected_hotkey[:8]}..., got {hotkey_part[:8]}...")
 
     ip, port_str = endpoint.rsplit(":", 1)
     return ip, int(port_str)

--- a/conversationgenome/commitment/commitment.py
+++ b/conversationgenome/commitment/commitment.py
@@ -59,22 +59,82 @@ def read_commitment(subtensor, netuid: int, hotkey_ss58: str) -> Optional[bytes]
         return None
 
 
+def _extract_ciphertext(commitment_data) -> Optional[bytes]:
+    """Extract ciphertext bytes from a commitment data structure."""
+    try:
+        commitment = commitment_data["info"]["fields"][0][0]
+        raw_key = next(iter(commitment.keys()))
+        return bytes(commitment[raw_key][0])
+    except Exception:
+        return None
+
+
 def read_all_commitments(
-    subtensor, netuid: int, hotkeys: list, private_key_bytes: bytes
+    subtensor, netuid: int, hotkeys: list, private_key_bytes: bytes,
+    cache: dict = None,
 ) -> dict:
-    """Read and decrypt commitments for all hotkeys. Returns {hotkey: (ip, port)}."""
-    total = len(hotkeys)
+    """Read and decrypt all commitments for a subnet in a single RPC call.
+
+    Uses query_map to fetch every commitment on the subnet at once (~0.6s),
+    then only decrypts entries whose block number changed since the last call.
+
+    Args:
+        cache: Dict of {hotkey: (block, ip, port)} from previous call.
+               Used to skip re-decrypting unchanged commitments.
+
+    Returns:
+        (endpoints, new_cache) tuple:
+            endpoints: {hotkey: (ip, port)} for use by the validator
+            new_cache: {hotkey: (block, ip, port)} to pass back on next call
+    """
+    if cache is None:
+        cache = {}
+
+    hotkey_set = set(hotkeys)
+
+    bt.logging.info(f"Fetching all commitments for subnet via query_map...")
+    try:
+        result = subtensor.query_map(
+            module="Commitments",
+            name="CommitmentOf",
+            params=[netuid],
+        )
+    except Exception as e:
+        bt.logging.error(f"query_map failed: {e}")
+        # Fall back to cached data
+        return {hk: (ip, port) for hk, (_, ip, port) in cache.items() if hk in hotkey_set}, cache
+
+    new_cache = {}
     endpoints = {}
-    bt.logging.info(f"Reading commitments: 0/{total} hotkeys...")
-    for i, hotkey in enumerate(hotkeys):
-        if (i + 1) % 50 == 0 or (i + 1) == total:
-            bt.logging.info(f"Reading commitments: {i + 1}/{total} hotkeys, {len(endpoints)} found so far...")
-        ciphertext = read_commitment(subtensor, netuid, hotkey)
+    found = 0
+    reused = 0
+
+    for hotkey, commitment_data in result:
+        hotkey_str = str(hotkey)
+        if hotkey_str not in hotkey_set:
+            continue
+
+        block = commitment_data.get("block", 0) if hasattr(commitment_data, "get") else 0
+
+        # If block hasn't changed, reuse cached decryption
+        if hotkey_str in cache and cache[hotkey_str][0] == block:
+            _, cached_ip, cached_port = cache[hotkey_str]
+            new_cache[hotkey_str] = (block, cached_ip, cached_port)
+            endpoints[hotkey_str] = (cached_ip, cached_port)
+            reused += 1
+            continue
+
+        ciphertext = _extract_ciphertext(commitment_data)
         if ciphertext is None:
             continue
+
         try:
             ip, port = decrypt_endpoint(ciphertext, private_key_bytes)
-            endpoints[hotkey] = (ip, port)
+            new_cache[hotkey_str] = (block, ip, port)
+            endpoints[hotkey_str] = (ip, port)
+            found += 1
         except Exception as e:
-            bt.logging.debug(f"Could not decrypt commitment for {hotkey}: {e}")
-    return endpoints
+            bt.logging.debug(f"Could not decrypt commitment for {hotkey_str}: {e}")
+
+    bt.logging.info(f"Commitments: {found} new, {reused} cached, {found + reused} total.")
+    return endpoints, new_cache

--- a/conversationgenome/commitment/commitment.py
+++ b/conversationgenome/commitment/commitment.py
@@ -63,8 +63,12 @@ def read_all_commitments(
     subtensor, netuid: int, hotkeys: list, private_key_bytes: bytes
 ) -> dict:
     """Read and decrypt commitments for all hotkeys. Returns {hotkey: (ip, port)}."""
+    total = len(hotkeys)
     endpoints = {}
-    for hotkey in hotkeys:
+    bt.logging.info(f"Reading commitments: 0/{total} hotkeys...")
+    for i, hotkey in enumerate(hotkeys):
+        if (i + 1) % 50 == 0 or (i + 1) == total:
+            bt.logging.info(f"Reading commitments: {i + 1}/{total} hotkeys, {len(endpoints)} found so far...")
         ciphertext = read_commitment(subtensor, netuid, hotkey)
         if ciphertext is None:
             continue

--- a/env.example
+++ b/env.example
@@ -115,6 +115,13 @@ export LOCAL_CGP_API_PORT=8000
 #export CGP_API_WRITE_HOST=http://localhost
 #export CGP_API_WRITE_PORT=$LOCAL_CGP_API_PORT
 
+# ____________ Encrypted Commitment Configuration: ____________
+# Shared NaCl keypair for encrypted endpoint commitments (hex-encoded, 32 bytes each)
+# Miners: set the public key to encrypt your ip:port before committing on-chain
+export COMMITMENT_PUBLIC_KEY=
+# Validators: set the private key to decrypt miner endpoint commitments
+export COMMITMENT_PRIVATE_KEY=
+
 # ____________ Debug Log: ____________
 # Optional, Commented by default.
 # Uncomment to set a path to log the conversation windows and tags you mine for analysis

--- a/env.example
+++ b/env.example
@@ -116,11 +116,10 @@ export LOCAL_CGP_API_PORT=8000
 #export CGP_API_WRITE_PORT=$LOCAL_CGP_API_PORT
 
 # ____________ Encrypted Commitment Configuration: ____________
-# Shared NaCl keypair for encrypted endpoint commitments (hex-encoded, 32 bytes each)
-# Miners: set the public key to encrypt your ip:port before committing on-chain
-export COMMITMENT_PUBLIC_KEY=
-# Validators: set the private key to decrypt miner endpoint commitments
-export COMMITMENT_PRIVATE_KEY=
+# Validators only. Miners have the public key built in.
+# Testnet private key (safe to share — testnet only):
+export COMMITMENT_PRIVATE_KEY=d0e8b84e89b085e0157dec62680987274eb1f136c7b6ac5bb7b2a21cce533294
+# For mainnet, the private key will be provided securely — do NOT commit it here.
 
 # ____________ Debug Log: ____________
 # Optional, Commented by default.

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -78,11 +78,13 @@ class Validator(BaseValidatorNeuron):
             ciphertext = read_commitment(self.subtensor, self.config.netuid, hotkey)
             if ciphertext is None:
                 return
-            ip, port = decrypt_endpoint(ciphertext, private_key_bytes)
+            ip, port = decrypt_endpoint(ciphertext, private_key_bytes, expected_hotkey=hotkey)
             self.committed_endpoints[hotkey] = (ip, port)
             # Use block 0 so the next query_map re-verifies against the real block.
             self._commitment_cache[hotkey] = (0, ip, port)
             bt.logging.info(f"Refreshed commitment for UID {uid} after failed request.")
+        except ValueError as e:
+            bt.logging.warning(f"Rejected commitment for UID {uid}: {e}")
         except Exception as e:
             bt.logging.debug(f"Could not refresh commitment for UID {uid}: {e}")
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -63,9 +63,9 @@ class Validator(BaseValidatorNeuron):
                 axon = copy.copy(axon)
                 axon.ip = ip
                 axon.port = port
-                bt.logging.info(f"UID {uid}: using committed endpoint {ip}:{port}")
+                bt.logging.info(f"UID {uid}: using committed endpoint")
             else:
-                bt.logging.info(f"UID {uid}: using metagraph endpoint {axon.ip}:{axon.port}")
+                bt.logging.info(f"UID {uid}: using metagraph endpoint")
             axons.append(axon)
         return axons
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -17,6 +17,7 @@
 
 
 import copy
+import os
 import random
 import time
 from typing import List
@@ -51,6 +52,26 @@ class Validator(BaseValidatorNeuron):
         self.responses = []
         self.initial_status_codes = {}
         self.final_status_codes = {}
+
+    def _refresh_commitment_for_uid(self, uid):
+        """Re-read and decrypt the commitment for a single miner UID."""
+        private_key_hex = os.environ.get("COMMITMENT_PRIVATE_KEY", "").strip()
+        if not private_key_hex:
+            return
+
+        try:
+            from conversationgenome.commitment.commitment import decrypt_endpoint, read_commitment
+
+            hotkey = self.metagraph.hotkeys[uid]
+            private_key_bytes = bytes.fromhex(private_key_hex)
+            ciphertext = read_commitment(self.subtensor, self.config.netuid, hotkey)
+            if ciphertext is None:
+                return
+            ip, port = decrypt_endpoint(ciphertext, private_key_bytes)
+            self.committed_endpoints[hotkey] = (ip, port)
+            bt.logging.info(f"Refreshed commitment for UID {uid} after failed request.")
+        except Exception as e:
+            bt.logging.debug(f"Could not refresh commitment for UID {uid}: {e}")
 
     def _get_axons_for_uids(self, uids):
         """Get axon list for UIDs, applying committed endpoint overrides when available."""
@@ -199,6 +220,10 @@ class Validator(BaseValidatorNeuron):
                         self.initial_status_codes[status_code] = self.initial_status_codes.get(status_code, 0) + 1
 
                         if status_code in [408, 422]:
+                            uids_to_retry.append(miner_uids[i])
+                        elif status_code is not None and str(status_code) == "503":
+                            bt.logging.info(f"503 for UID {miner_uids[i]} — refreshing commitment and retrying.")
+                            self._refresh_commitment_for_uid(miner_uids[i])
                             uids_to_retry.append(miner_uids[i])
                         elif status_code is not None and str(status_code).startswith("5"):
                             bt.logging.info(f"5xx status code detected: {status_code} for UID {miner_uids[i]}")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -16,6 +16,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
+import copy
 import random
 import time
 from typing import List
@@ -50,6 +51,23 @@ class Validator(BaseValidatorNeuron):
         self.responses = []
         self.initial_status_codes = {}
         self.final_status_codes = {}
+
+    def _get_axons_for_uids(self, uids):
+        """Get axon list for UIDs, applying committed endpoint overrides when available."""
+        axons = []
+        for uid in uids:
+            axon = self.metagraph.axons[uid]
+            hotkey = self.metagraph.hotkeys[uid]
+            if hotkey in self.committed_endpoints:
+                ip, port = self.committed_endpoints[hotkey]
+                axon = copy.copy(axon)
+                axon.ip = ip
+                axon.port = port
+                bt.logging.info(f"UID {uid}: using committed endpoint {ip}:{port}")
+            else:
+                bt.logging.info(f"UID {uid}: using metagraph endpoint {axon.ip}:{axon.port}")
+            axons.append(axon)
+        return axons
 
     async def forward(self, test_mode=False):
         try:
@@ -163,7 +181,7 @@ class Validator(BaseValidatorNeuron):
                 synapse = conversationgenome.protocol.CgSynapse(cgp_input=[{"task": masked_task}])
 
                 responses = await self.dendrite.forward(
-                    axons=[self.metagraph.axons[uid] for uid in miner_uids],
+                    axons=self._get_axons_for_uids(miner_uids),
                     synapse=synapse,
                     deserialize=False,
                 )
@@ -192,7 +210,7 @@ class Validator(BaseValidatorNeuron):
                     bt.logging.debug(f"Retrying requests for the following UIDs (same synapse): {uids_to_retry}")
 
                     retry_responses = await self.dendrite.forward(
-                        axons=[self.metagraph.axons[uid] for uid in uids_to_retry],
+                        axons=self._get_axons_for_uids(uids_to_retry),
                         synapse=synapse,
                         deserialize=False,
                     )

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -55,7 +55,7 @@ class Validator(BaseValidatorNeuron):
         self._uid_refresh_timestamps: dict = {}  # {uid: last_refresh_time}
 
     def _refresh_commitment_for_uid(self, uid):
-        """Re-read and decrypt the commitment for a single miner UID. Debounced to 60s per UID."""
+        """Re-read and decrypt the commitment for a single miner UID. Debounced to 5 min per UID."""
         import time as _time
 
         now = _time.time()
@@ -73,6 +73,9 @@ class Validator(BaseValidatorNeuron):
         try:
             from conversationgenome.commitment.commitment import decrypt_endpoint, read_commitment
 
+            if uid >= len(self.metagraph.hotkeys):
+                bt.logging.debug(f"UID {uid} out of range for current metagraph, skipping commitment refresh.")
+                return
             hotkey = self.metagraph.hotkeys[uid]
             private_key_bytes = bytes.fromhex(private_key_hex)
             ciphertext = read_commitment(self.subtensor, self.config.netuid, hotkey)
@@ -84,6 +87,11 @@ class Validator(BaseValidatorNeuron):
             self._commitment_cache[hotkey] = (0, ip, port)
             bt.logging.info(f"Refreshed commitment for UID {uid} after failed request.")
         except ValueError as e:
+            # Commitment is invalid (hotkey mismatch, old format, etc.) — evict from cache
+            hotkey = self.metagraph.hotkeys[uid] if uid < len(self.metagraph.hotkeys) else None
+            if hotkey:
+                self.committed_endpoints.pop(hotkey, None)
+                self._commitment_cache.pop(hotkey, None)
             bt.logging.warning(f"Rejected commitment for UID {uid}: {e}")
         except Exception as e:
             bt.logging.debug(f"Could not refresh commitment for UID {uid}: {e}")
@@ -92,6 +100,9 @@ class Validator(BaseValidatorNeuron):
         """Get axon list for UIDs, applying committed endpoint overrides when available."""
         axons = []
         for uid in uids:
+            if uid >= len(self.metagraph.axons) or uid >= len(self.metagraph.hotkeys):
+                bt.logging.debug(f"UID {uid} out of range, skipping.")
+                continue
             axon = self.metagraph.axons[uid]
             hotkey = self.metagraph.hotkeys[uid]
             if hotkey in self.committed_endpoints:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -232,7 +232,7 @@ class Validator(BaseValidatorNeuron):
                     if status_code is not None:
                         self.initial_status_codes[status_code] = self.initial_status_codes.get(status_code, 0) + 1
 
-                        if status_code in [408, 422, 503] or (status_code is not None and str(status_code).startswith("5")):
+                        if status_code in [408, 422, 503]:
                             self._refresh_commitment_for_uid(miner_uids[i])
                             uids_to_retry.append(miner_uids[i])
                             bt.logging.info(f"{status_code} for UID {miner_uids[i]} — refreshing commitment and retrying.")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -219,14 +219,10 @@ class Validator(BaseValidatorNeuron):
                     if status_code is not None:
                         self.initial_status_codes[status_code] = self.initial_status_codes.get(status_code, 0) + 1
 
-                        if status_code in [408, 422]:
-                            uids_to_retry.append(miner_uids[i])
-                        elif status_code is not None and str(status_code) == "503":
-                            bt.logging.info(f"503 for UID {miner_uids[i]} — refreshing commitment and retrying.")
+                        if status_code in [408, 422, 503] or (status_code is not None and str(status_code).startswith("5")):
                             self._refresh_commitment_for_uid(miner_uids[i])
                             uids_to_retry.append(miner_uids[i])
-                        elif status_code is not None and str(status_code).startswith("5"):
-                            bt.logging.info(f"5xx status code detected: {status_code} for UID {miner_uids[i]}")
+                            bt.logging.info(f"{status_code} for UID {miner_uids[i]} — refreshing commitment and retrying.")
 
                 uid_to_index = {uid: idx for idx, uid in enumerate(miner_uids)}
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -69,6 +69,8 @@ class Validator(BaseValidatorNeuron):
                 return
             ip, port = decrypt_endpoint(ciphertext, private_key_bytes)
             self.committed_endpoints[hotkey] = (ip, port)
+            # Use block 0 so the next query_map re-verifies against the real block.
+            self._commitment_cache[hotkey] = (0, ip, port)
             bt.logging.info(f"Refreshed commitment for UID {uid} after failed request.")
         except Exception as e:
             bt.logging.debug(f"Could not refresh commitment for UID {uid}: {e}")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -52,12 +52,23 @@ class Validator(BaseValidatorNeuron):
         self.responses = []
         self.initial_status_codes = {}
         self.final_status_codes = {}
+        self._uid_refresh_timestamps: dict = {}  # {uid: last_refresh_time}
 
     def _refresh_commitment_for_uid(self, uid):
-        """Re-read and decrypt the commitment for a single miner UID."""
+        """Re-read and decrypt the commitment for a single miner UID. Debounced to 60s per UID."""
+        import time as _time
+
+        now = _time.time()
+        last = self._uid_refresh_timestamps.get(uid, 0)
+        if now - last < 300:
+            bt.logging.debug(f"Skipping commitment refresh for UID {uid} — last refresh was {int(now - last)}s ago.")
+            return
+
         private_key_hex = os.environ.get("COMMITMENT_PRIVATE_KEY", "").strip()
         if not private_key_hex:
             return
+
+        self._uid_refresh_timestamps[uid] = now
 
         try:
             from conversationgenome.commitment.commitment import decrypt_endpoint, read_commitment

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pydantic==2.7.1
 typing-extensions==4.8.0
 httpx==0.27.2
 async-substrate-interface==1.6.4
+pynacl

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ pydantic==2.7.1
 typing-extensions==4.8.0
 httpx==0.27.2
 async-substrate-interface==1.6.4
-pynacl
+pynacl==1.6.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -14,3 +14,5 @@ pytest-asyncio
 pydantic==2.7.1
 typing-extensions==4.8.0
 httpx==0.27.2
+async-substrate-interface==1.6.4
+pynacl

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -15,4 +15,4 @@ pydantic==2.7.1
 typing-extensions==4.8.0
 httpx==0.27.2
 async-substrate-interface==1.6.4
-pynacl
+pynacl==1.6.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,6 +135,9 @@ def bare_validator(monkeypatch):
     v.responses = []
     v.initial_status_codes = {}
     v.final_status_codes = {}
+    v.committed_endpoints = {}
+    v._commitment_cache = {}
+    v._uid_refresh_timestamps = {}
 
     v.axon = type("Ax", (), {"wallet": type("W", (), {"hotkey": type("H", (), {"ss58_address": "HK"})()})()})()
     v.metagraph = type(

--- a/tests/unit/test_Validator.py
+++ b/tests/unit/test_Validator.py
@@ -248,7 +248,7 @@ async def test_forward_handles_missing_cgp_output(bare_validator, fake_libs, mon
             self.cgp_output = None  # Simulate missing cgp_output
 
     validator.dendrite.forward = AsyncMock(side_effect=lambda axons, *_, **__: [DummyResponseNoCGP(axon.hotkey) for axon in axons])
-    validator.metagraph.hotkeys = ["hk"]
+    validator.metagraph.hotkeys = ["hk0", "hk1", "hk2"]
     validator.update_scores = MagicMock()
 
     result = await validator.forward(test_mode=True)

--- a/tests/unit/test_commitment.py
+++ b/tests/unit/test_commitment.py
@@ -27,44 +27,61 @@ def _generate_keypair():
 class TestEncryptDecrypt:
     def test_round_trip_basic(self):
         pub, priv = _generate_keypair()
-        ct = encrypt_endpoint("192.168.1.100", 8091, pub)
-        ip, port = decrypt_endpoint(ct, priv)
+        ct = encrypt_endpoint("192.168.1.100", 8091, pub, hotkey="5FakeHotkey")
+        ip, port = decrypt_endpoint(ct, priv, expected_hotkey="5FakeHotkey")
         assert ip == "192.168.1.100"
         assert port == 8091
 
     def test_round_trip_worst_case_ipv4(self):
         pub, priv = _generate_keypair()
-        ct = encrypt_endpoint("255.255.255.255", 65535, pub)
-        ip, port = decrypt_endpoint(ct, priv)
+        ct = encrypt_endpoint("255.255.255.255", 65535, pub, hotkey="5FakeHotkey")
+        ip, port = decrypt_endpoint(ct, priv, expected_hotkey="5FakeHotkey")
         assert ip == "255.255.255.255"
         assert port == 65535
 
     def test_round_trip_localhost(self):
         pub, priv = _generate_keypair()
-        ct = encrypt_endpoint("127.0.0.1", 1, pub)
-        ip, port = decrypt_endpoint(ct, priv)
+        ct = encrypt_endpoint("127.0.0.1", 1, pub, hotkey="5FakeHotkey")
+        ip, port = decrypt_endpoint(ct, priv, expected_hotkey="5FakeHotkey")
         assert ip == "127.0.0.1"
         assert port == 1
 
     def test_ciphertext_differs_each_time(self):
         """Sealed boxes use ephemeral keys, so encrypting the same plaintext twice produces different ciphertext."""
         pub, _ = _generate_keypair()
-        ct1 = encrypt_endpoint("10.0.0.1", 8080, pub)
-        ct2 = encrypt_endpoint("10.0.0.1", 8080, pub)
+        ct1 = encrypt_endpoint("10.0.0.1", 8080, pub, hotkey="5FakeHotkey")
+        ct2 = encrypt_endpoint("10.0.0.1", 8080, pub, hotkey="5FakeHotkey")
         assert ct1 != ct2
 
     def test_ciphertext_size_within_limit(self):
-        """Worst-case IPv4:port is 21 bytes plaintext -> 69 bytes ciphertext, well within the 128-byte Raw limit."""
+        """Worst-case: 48-char hotkey + | + 21-char ip:port = 70 bytes plaintext + 48 overhead = 118 bytes."""
         pub, _ = _generate_keypair()
-        ct = encrypt_endpoint("255.255.255.255", 65535, pub)
+        worst_case_hotkey = "5" * 48  # SS58 hotkeys are up to 48 chars
+        ct = encrypt_endpoint("255.255.255.255", 65535, pub, hotkey=worst_case_hotkey)
         assert len(ct) <= 128
 
     def test_wrong_key_fails(self):
         pub1, _ = _generate_keypair()
         _, priv2 = _generate_keypair()
-        ct = encrypt_endpoint("10.0.0.1", 8080, pub1)
+        ct = encrypt_endpoint("10.0.0.1", 8080, pub1, hotkey="5FakeHotkey")
         with pytest.raises(Exception):
             decrypt_endpoint(ct, priv2)
+
+    def test_hotkey_mismatch_rejected(self):
+        """Copying another miner's commitment should be rejected due to hotkey mismatch."""
+        pub, priv = _generate_keypair()
+        ct = encrypt_endpoint("10.0.0.1", 8080, pub, hotkey="5MinerA")
+        with pytest.raises(ValueError, match="mismatch"):
+            decrypt_endpoint(ct, priv, expected_hotkey="5MinerB")
+
+    def test_backwards_compatible_no_hotkey(self):
+        """Old format commitments (ip:port without hotkey) should still decrypt."""
+        pub, priv = _generate_keypair()
+        # Simulate old format by encrypting without hotkey
+        ct = encrypt_endpoint("10.0.0.1", 8080, pub)
+        ip, port = decrypt_endpoint(ct, priv)
+        assert ip == "10.0.0.1"
+        assert port == 8080
 
 
 # ── publish_commitment ───────────────────────────────────────────────
@@ -154,8 +171,8 @@ class TestReadAllCommitments:
 
     def test_decrypts_all_available(self):
         pub, priv = _generate_keypair()
-        ct1 = encrypt_endpoint("10.0.0.1", 8080, pub)
-        ct2 = encrypt_endpoint("10.0.0.2", 9090, pub)
+        ct1 = encrypt_endpoint("10.0.0.1", 8080, pub, hotkey="hk0")
+        ct2 = encrypt_endpoint("10.0.0.2", 9090, pub, hotkey="hk1")
 
         query_map_result = [
             ("hk0", self._make_commitment_data(ct1, block=10)),
@@ -178,7 +195,7 @@ class TestReadAllCommitments:
     def test_skips_undecryptable(self):
         pub1, _ = _generate_keypair()
         _, priv2 = _generate_keypair()
-        ct = encrypt_endpoint("10.0.0.1", 8080, pub1)
+        ct = encrypt_endpoint("10.0.0.1", 8080, pub1, hotkey="hk0")
 
         query_map_result = [
             ("hk0", self._make_commitment_data(ct, block=10)),
@@ -193,9 +210,29 @@ class TestReadAllCommitments:
         assert endpoints == {}
         assert cache == {}
 
+    def test_rejects_copied_commitment(self):
+        """A miner copying another miner's commitment should be rejected."""
+        pub, priv = _generate_keypair()
+        # hk0 encrypts with its own hotkey
+        ct = encrypt_endpoint("10.0.0.1", 8080, pub, hotkey="hk0")
+
+        # hk1 copies hk0's ciphertext
+        query_map_result = [
+            ("hk0", self._make_commitment_data(ct, block=10)),
+            ("hk1", self._make_commitment_data(ct, block=10)),  # copied!
+        ]
+
+        subtensor = MagicMock()
+        subtensor.query_map.return_value = query_map_result
+
+        endpoints, cache = read_all_commitments(subtensor, 138, ["hk0", "hk1"], priv)
+
+        assert endpoints["hk0"] == ("10.0.0.1", 8080)
+        assert "hk1" not in endpoints  # rejected due to hotkey mismatch
+
     def test_reuses_cache_when_block_unchanged(self):
         pub, priv = _generate_keypair()
-        ct = encrypt_endpoint("10.0.0.1", 8080, pub)
+        ct = encrypt_endpoint("10.0.0.1", 8080, pub, hotkey="hk0")
 
         query_map_result = [
             ("hk0", self._make_commitment_data(ct, block=10)),
@@ -215,8 +252,8 @@ class TestReadAllCommitments:
 
     def test_re_decrypts_when_block_changes(self):
         pub, priv = _generate_keypair()
-        ct1 = encrypt_endpoint("10.0.0.1", 8080, pub)
-        ct2 = encrypt_endpoint("10.0.0.2", 9090, pub)
+        ct1 = encrypt_endpoint("10.0.0.1", 8080, pub, hotkey="hk0")
+        ct2 = encrypt_endpoint("10.0.0.2", 9090, pub, hotkey="hk0")
 
         subtensor = MagicMock()
 

--- a/tests/unit/test_commitment.py
+++ b/tests/unit/test_commitment.py
@@ -1,0 +1,232 @@
+"""Tests for the encrypted commitment system."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from nacl.public import PrivateKey
+
+from conversationgenome.commitment.commitment import (
+    decrypt_endpoint,
+    encrypt_endpoint,
+    publish_commitment,
+    read_all_commitments,
+    read_commitment,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+def _generate_keypair():
+    """Generate a fresh NaCl keypair and return (public_bytes, private_bytes)."""
+    private = PrivateKey.generate()
+    return bytes(private.public_key), bytes(private)
+
+
+# ── encrypt / decrypt round-trip ─────────────────────────────────────
+
+class TestEncryptDecrypt:
+    def test_round_trip_basic(self):
+        pub, priv = _generate_keypair()
+        ct = encrypt_endpoint("192.168.1.100", 8091, pub)
+        ip, port = decrypt_endpoint(ct, priv)
+        assert ip == "192.168.1.100"
+        assert port == 8091
+
+    def test_round_trip_worst_case_ipv4(self):
+        pub, priv = _generate_keypair()
+        ct = encrypt_endpoint("255.255.255.255", 65535, pub)
+        ip, port = decrypt_endpoint(ct, priv)
+        assert ip == "255.255.255.255"
+        assert port == 65535
+
+    def test_round_trip_localhost(self):
+        pub, priv = _generate_keypair()
+        ct = encrypt_endpoint("127.0.0.1", 1, pub)
+        ip, port = decrypt_endpoint(ct, priv)
+        assert ip == "127.0.0.1"
+        assert port == 1
+
+    def test_ciphertext_differs_each_time(self):
+        """Sealed boxes use ephemeral keys, so encrypting the same plaintext twice produces different ciphertext."""
+        pub, _ = _generate_keypair()
+        ct1 = encrypt_endpoint("10.0.0.1", 8080, pub)
+        ct2 = encrypt_endpoint("10.0.0.1", 8080, pub)
+        assert ct1 != ct2
+
+    def test_ciphertext_size_within_limit(self):
+        """Worst-case IPv4:port is 21 bytes plaintext -> 69 bytes ciphertext, well within the 128-byte Raw limit."""
+        pub, _ = _generate_keypair()
+        ct = encrypt_endpoint("255.255.255.255", 65535, pub)
+        assert len(ct) <= 128
+
+    def test_wrong_key_fails(self):
+        pub1, _ = _generate_keypair()
+        _, priv2 = _generate_keypair()
+        ct = encrypt_endpoint("10.0.0.1", 8080, pub1)
+        with pytest.raises(Exception):
+            decrypt_endpoint(ct, priv2)
+
+
+# ── publish_commitment ───────────────────────────────────────────────
+
+class TestPublishCommitment:
+    def test_success(self):
+        with patch(
+            "bittensor.core.extrinsics.serving.publish_metadata"
+        ) as mock_pub:
+            result = publish_commitment(
+                subtensor=MagicMock(),
+                wallet=MagicMock(),
+                netuid=138,
+                ciphertext=b"\x01" * 69,
+            )
+            assert result is True
+            mock_pub.assert_called_once()
+            call_kwargs = mock_pub.call_args.kwargs
+            assert call_kwargs["data_type"] == "Raw69"
+            assert call_kwargs["data"] == b"\x01" * 69
+
+    def test_rate_limit_returns_false(self):
+        with patch(
+            "bittensor.core.extrinsics.serving.publish_metadata",
+            side_effect=Exception("rate limit exceeded"),
+        ):
+            result = publish_commitment(
+                subtensor=MagicMock(),
+                wallet=MagicMock(),
+                netuid=138,
+                ciphertext=b"\x01" * 69,
+            )
+            assert result is False
+
+    def test_generic_error_returns_false(self):
+        with patch(
+            "bittensor.core.extrinsics.serving.publish_metadata",
+            side_effect=Exception("something broke"),
+        ):
+            result = publish_commitment(
+                subtensor=MagicMock(),
+                wallet=MagicMock(),
+                netuid=138,
+                ciphertext=b"\x01" * 69,
+            )
+            assert result is False
+
+
+# ── read_commitment ──────────────────────────────────────────────────
+
+class TestReadCommitment:
+    def test_reads_ciphertext_from_metadata(self):
+        pub, _ = _generate_keypair()
+        ct = encrypt_endpoint("10.0.0.1", 9000, pub)
+        metadata = {"info": {"fields": [[{"Raw69": [list(ct)]}]]}}
+
+        with patch(
+            "bittensor.core.extrinsics.serving.get_metadata",
+            return_value=metadata,
+        ):
+            result = read_commitment(MagicMock(), 138, "5FakeHotkey")
+            assert result == ct
+
+    def test_returns_none_when_no_metadata(self):
+        with patch(
+            "bittensor.core.extrinsics.serving.get_metadata",
+            return_value=None,
+        ):
+            result = read_commitment(MagicMock(), 138, "5FakeHotkey")
+            assert result is None
+
+    def test_returns_none_on_exception(self):
+        with patch(
+            "bittensor.core.extrinsics.serving.get_metadata",
+            side_effect=Exception("network error"),
+        ):
+            result = read_commitment(MagicMock(), 138, "5FakeHotkey")
+            assert result is None
+
+
+# ── read_all_commitments ─────────────────────────────────────────────
+
+class TestReadAllCommitments:
+    def test_decrypts_all_available(self):
+        pub, priv = _generate_keypair()
+        ct1 = encrypt_endpoint("10.0.0.1", 8080, pub)
+        ct2 = encrypt_endpoint("10.0.0.2", 9090, pub)
+
+        def fake_get_metadata(subtensor, netuid, hotkey):
+            ciphertexts = {"hk0": ct1, "hk1": ct2}
+            ct = ciphertexts.get(hotkey)
+            if ct is None:
+                return None
+            return {"info": {"fields": [[{f"Raw{len(ct)}": [list(ct)]}]]}}
+
+        with patch(
+            "bittensor.core.extrinsics.serving.get_metadata",
+            side_effect=fake_get_metadata,
+        ):
+            endpoints = read_all_commitments(
+                MagicMock(), 138, ["hk0", "hk1", "hk2"], priv
+            )
+
+        assert endpoints["hk0"] == ("10.0.0.1", 8080)
+        assert endpoints["hk1"] == ("10.0.0.2", 9090)
+        assert "hk2" not in endpoints
+
+    def test_skips_undecryptable(self):
+        pub1, _ = _generate_keypair()
+        _, priv2 = _generate_keypair()
+        ct = encrypt_endpoint("10.0.0.1", 8080, pub1)
+
+        metadata = {"info": {"fields": [[{f"Raw{len(ct)}": [list(ct)]}]]}}
+        with patch(
+            "bittensor.core.extrinsics.serving.get_metadata",
+            return_value=metadata,
+        ):
+            # priv2 can't decrypt ct encrypted with pub1
+            endpoints = read_all_commitments(MagicMock(), 138, ["hk0"], priv2)
+
+        assert endpoints == {}
+
+
+# ── validator integration ────────────────────────────────────────────
+
+class TestValidatorIntegration:
+    @staticmethod
+    def _add_ip_port_to_axons(validator):
+        """Add ip/port attrs to the mock axon objects so _get_axons_for_uids can log them."""
+        for i, axon in enumerate(validator.metagraph.axons):
+            axon.ip = f"10.0.0.{i}"
+            axon.port = 8000 + i
+
+    def test_get_axons_uses_committed_endpoint(self, bare_validator):
+        """When a committed endpoint exists, _get_axons_for_uids should override the axon ip/port."""
+        self._add_ip_port_to_axons(bare_validator)
+        bare_validator.committed_endpoints = {"hk1": ("10.99.99.99", 1234)}
+        axons = bare_validator._get_axons_for_uids([0, 1, 2])
+
+        assert axons[1].ip == "10.99.99.99"
+        assert axons[1].port == 1234
+        assert axons[0].ip == "10.0.0.0"
+        assert len(axons) == 3
+
+    def test_get_axons_no_committed_endpoints(self, bare_validator):
+        """When no commitments exist, axons come straight from metagraph."""
+        self._add_ip_port_to_axons(bare_validator)
+        bare_validator.committed_endpoints = {}
+        axons = bare_validator._get_axons_for_uids([0, 1, 2])
+        # All 3 axons returned unchanged
+        assert len(axons) == 3
+        assert axons[0] is bare_validator.metagraph.axons[0]
+
+    def test_committed_endpoint_does_not_mutate_metagraph(self, bare_validator):
+        """The override should copy the axon, not mutate the metagraph's version."""
+        self._add_ip_port_to_axons(bare_validator)
+        bare_validator.metagraph.axons[1].ip = "original"
+        bare_validator.metagraph.axons[1].port = 5555
+        bare_validator.committed_endpoints = {"hk1": ("10.99.99.99", 1234)}
+
+        axons = bare_validator._get_axons_for_uids([1])
+        assert axons[0].ip == "10.99.99.99"
+        # Original metagraph axon should be untouched
+        assert bare_validator.metagraph.axons[1].ip == "original"
+        assert bare_validator.metagraph.axons[1].port == 5555

--- a/tests/unit/test_commitment.py
+++ b/tests/unit/test_commitment.py
@@ -148,44 +148,87 @@ class TestReadCommitment:
 # ── read_all_commitments ─────────────────────────────────────────────
 
 class TestReadAllCommitments:
+    @staticmethod
+    def _make_commitment_data(ciphertext, block=100):
+        return {"block": block, "info": {"fields": [[{f"Raw{len(ciphertext)}": [list(ciphertext)]}]]}}
+
     def test_decrypts_all_available(self):
         pub, priv = _generate_keypair()
         ct1 = encrypt_endpoint("10.0.0.1", 8080, pub)
         ct2 = encrypt_endpoint("10.0.0.2", 9090, pub)
 
-        def fake_get_metadata(subtensor, netuid, hotkey):
-            ciphertexts = {"hk0": ct1, "hk1": ct2}
-            ct = ciphertexts.get(hotkey)
-            if ct is None:
-                return None
-            return {"info": {"fields": [[{f"Raw{len(ct)}": [list(ct)]}]]}}
+        query_map_result = [
+            ("hk0", self._make_commitment_data(ct1, block=10)),
+            ("hk1", self._make_commitment_data(ct2, block=20)),
+        ]
 
-        with patch(
-            "bittensor.core.extrinsics.serving.get_metadata",
-            side_effect=fake_get_metadata,
-        ):
-            endpoints = read_all_commitments(
-                MagicMock(), 138, ["hk0", "hk1", "hk2"], priv
-            )
+        subtensor = MagicMock()
+        subtensor.query_map.return_value = query_map_result
+
+        endpoints, cache = read_all_commitments(
+            subtensor, 138, ["hk0", "hk1", "hk2"], priv
+        )
 
         assert endpoints["hk0"] == ("10.0.0.1", 8080)
         assert endpoints["hk1"] == ("10.0.0.2", 9090)
         assert "hk2" not in endpoints
+        assert "hk0" in cache
+        assert "hk1" in cache
 
     def test_skips_undecryptable(self):
         pub1, _ = _generate_keypair()
         _, priv2 = _generate_keypair()
         ct = encrypt_endpoint("10.0.0.1", 8080, pub1)
 
-        metadata = {"info": {"fields": [[{f"Raw{len(ct)}": [list(ct)]}]]}}
-        with patch(
-            "bittensor.core.extrinsics.serving.get_metadata",
-            return_value=metadata,
-        ):
-            # priv2 can't decrypt ct encrypted with pub1
-            endpoints = read_all_commitments(MagicMock(), 138, ["hk0"], priv2)
+        query_map_result = [
+            ("hk0", self._make_commitment_data(ct, block=10)),
+        ]
+
+        subtensor = MagicMock()
+        subtensor.query_map.return_value = query_map_result
+
+        # priv2 can't decrypt ct encrypted with pub1
+        endpoints, cache = read_all_commitments(subtensor, 138, ["hk0"], priv2)
 
         assert endpoints == {}
+        assert cache == {}
+
+    def test_reuses_cache_when_block_unchanged(self):
+        pub, priv = _generate_keypair()
+        ct = encrypt_endpoint("10.0.0.1", 8080, pub)
+
+        query_map_result = [
+            ("hk0", self._make_commitment_data(ct, block=10)),
+        ]
+
+        subtensor = MagicMock()
+        subtensor.query_map.return_value = query_map_result
+
+        # First call populates cache
+        endpoints, cache = read_all_commitments(subtensor, 138, ["hk0"], priv)
+        assert endpoints["hk0"] == ("10.0.0.1", 8080)
+
+        # Second call with same block — should reuse cache, not re-decrypt
+        endpoints2, cache2 = read_all_commitments(subtensor, 138, ["hk0"], priv, cache=cache)
+        assert endpoints2["hk0"] == ("10.0.0.1", 8080)
+        assert cache2["hk0"] == cache["hk0"]
+
+    def test_re_decrypts_when_block_changes(self):
+        pub, priv = _generate_keypair()
+        ct1 = encrypt_endpoint("10.0.0.1", 8080, pub)
+        ct2 = encrypt_endpoint("10.0.0.2", 9090, pub)
+
+        subtensor = MagicMock()
+
+        # First call
+        subtensor.query_map.return_value = [("hk0", self._make_commitment_data(ct1, block=10))]
+        endpoints, cache = read_all_commitments(subtensor, 138, ["hk0"], priv)
+        assert endpoints["hk0"] == ("10.0.0.1", 8080)
+
+        # Second call with new block and new ciphertext
+        subtensor.query_map.return_value = [("hk0", self._make_commitment_data(ct2, block=20))]
+        endpoints2, cache2 = read_all_commitments(subtensor, 138, ["hk0"], priv, cache=cache)
+        assert endpoints2["hk0"] == ("10.0.0.2", 9090)
 
 
 # ── validator integration ────────────────────────────────────────────

--- a/tests/unit/test_commitment.py
+++ b/tests/unit/test_commitment.py
@@ -74,14 +74,15 @@ class TestEncryptDecrypt:
         with pytest.raises(ValueError, match="mismatch"):
             decrypt_endpoint(ct, priv, expected_hotkey="5MinerB")
 
-    def test_backwards_compatible_no_hotkey(self):
-        """Old format commitments (ip:port without hotkey) should still decrypt."""
+    def test_old_format_without_hotkey_rejected(self):
+        """Old format commitments (ip:port without hotkey) should be rejected."""
         pub, priv = _generate_keypair()
-        # Simulate old format by encrypting without hotkey
-        ct = encrypt_endpoint("10.0.0.1", 8080, pub)
-        ip, port = decrypt_endpoint(ct, priv)
-        assert ip == "10.0.0.1"
-        assert port == 8080
+        # Simulate old format by manually encrypting just "ip:port" without pipe
+        from nacl.public import PublicKey, SealedBox
+        box = SealedBox(PublicKey(pub))
+        ct = box.encrypt(b"10.0.0.1:8080")
+        with pytest.raises(ValueError, match="old format no longer supported"):
+            decrypt_endpoint(ct, priv)
 
 
 # ── publish_commitment ───────────────────────────────────────────────


### PR DESCRIPTION
- Miners encrypt their `ip:port` using a NaCl sealed box and commit the ciphertext on-chain via publish_metadata. The metagraph only sees a dummy non-routable address (`192.0.2.1:1234`), hiding the real endpoint from scrapers.                                - Validators fetch all commitments in a single query_map RPC call, decrypt miner endpoints with a shared private key, and use them to connect. Block-based caching avoids redundant decryption.
- On any failed request, the validator re-reads that miner's commitment from chain (at most once every 5 minutes) and retries with the fresh endpoint.                                          
- A log filter redacts all IP addresses from bittensor's internal dendrite logs and drops connection error messages entirely to prevent leaking miner IPs in validator logs.      
- Separate keypairs for testnet (netuid 138) and mainnet (netuid 33). Miner public keys are built into the code. Testnet private key is included in `env.example`; mainnet private key is distributed securely.