### PR TITLE
give minimal baseline weight to miners to unblock consensus

### DIFF
--- a/conversationgenome/base/validator.py
+++ b/conversationgenome/base/validator.py
@@ -35,6 +35,7 @@ from conversationgenome.base.neuron import BaseNeuron
 from conversationgenome.ConfigLib import c
 from conversationgenome.mock.mock import MockDendrite
 from conversationgenome.utils.config import add_validator_args
+from conversationgenome.utils.uids import check_uid_availability
 from conversationgenome.validator.ValidatorLib import ValidatorLib
 
 
@@ -306,7 +307,21 @@ class BaseValidatorNeuron(BaseNeuron):
         burn_uid = self.get_burn_uid()
         burn_rate = self.burn_rate
 
-        raw_weights = vl.get_raw_weights(self.scores, burn_uid=burn_uid, burn_rate=burn_rate)
+        # Eligible UIDs receive a tiny baseline weight even if their score is 0,
+        # so a miner that has never been sampled (or had a transient failure) is
+        # not permanently locked out of the cubic distribution. Filter matches
+        # the sampling filter in get_random_uids -> check_uid_availability.
+        eligible_uids = [
+            uid for uid in range(self.metagraph.n.item())
+            if check_uid_availability(self.metagraph, uid, self.config.neuron.vpermit_tao_limit)
+        ]
+
+        raw_weights = vl.get_raw_weights(
+            self.scores,
+            burn_uid=burn_uid,
+            burn_rate=burn_rate,
+            eligible_uids=eligible_uids,
+        )
 
         if raw_weights is None or raw_weights.size == 0:
             bt.logging.error("Error Generating raw weights. Returning without setting weights")

--- a/conversationgenome/validator/ValidatorLib.py
+++ b/conversationgenome/validator/ValidatorLib.py
@@ -3,6 +3,7 @@ verbose = False
 import json
 import os
 from typing import Any
+from typing import Iterable
 from typing import Optional
 
 import numpy as np
@@ -172,11 +173,17 @@ class ValidatorLib:
 
         return y_scaled
 
+    # Smallest weight that survives the chain's u16 normalization is 1/65535.
+    # We use a slight multiple to keep some safety margin against rounding
+    # after the cubic-bucket renormalization step below.
+    BASELINE_WEIGHT = 5.0 / 65535.0
+
     def get_raw_weights(
         self,
         scores,
         burn_uid: Optional[int] = None,
         burn_rate: Optional[float] = 0.0,
+        eligible_uids: Optional[Iterable[int]] = None,
     ):
         if scores is None or scores.size == 0 or np.isnan(scores).any():
             bt.logging.error("Nan detected in Weights. Returning None.")
@@ -230,6 +237,19 @@ class ValidatorLib:
                 else:
                     bt.logging.error("Error in Weights calculation. Setting this UID to 0")
                     temp_weights[uid] = 0.0
+
+            # Baseline weight for serving non-validator UIDs that we have never
+            # scored, so they aren't permanently excluded from consensus on
+            # subnets where stake is concentrated in burn-only validators.
+            # Caller passes the eligible UID set (typically serving miners with
+            # check_uid_availability == True). Self and burn_uid are skipped.
+            if eligible_uids is not None:
+                eligible_set = {int(u) for u in eligible_uids}
+                if burn_uid is not None:
+                    eligible_set.discard(int(burn_uid))
+                for uid in eligible_set:
+                    if 0 <= uid < temp_weights.shape[0] and temp_weights[uid] == 0:
+                        temp_weights[uid] = self.BASELINE_WEIGHT
 
             sum_temp = float(np.sum(np.abs(temp_weights)))
             if sum_temp > 0:

--- a/tests/unit/test_ValidatorLib_weights.py
+++ b/tests/unit/test_ValidatorLib_weights.py
@@ -89,6 +89,42 @@ def test_get_raw_weights_distribution_with_burn():
     assert weights[burn_uid] == pytest.approx(np.max(weights))
 
 
+def test_get_raw_weights_baseline_for_eligible_zero_score_uids():
+    """Score-0 UIDs in the eligible set receive a small baseline weight; uneligible
+    score-0 UIDs (and the burn_uid) stay at zero."""
+    vl = ValidatorLib()
+
+    burn_uid = 4
+    burn_rate = 0.9
+
+    # UIDs 0,1,2 scored; 3 and 5 are zero. Pretend 3 is serving (eligible) and 5 isn't.
+    scores = np.array([0.2, 0.5, 0.3, 0.0, 0.0, 0.0], dtype=float)
+    eligible_uids = [0, 1, 2, 3]  # excludes 4 (burn) and 5 (not serving)
+
+    weights = vl.get_raw_weights(
+        scores=scores,
+        burn_uid=burn_uid,
+        burn_rate=burn_rate,
+        eligible_uids=eligible_uids,
+    )
+
+    assert weights[burn_uid] == pytest.approx(burn_rate, rel=1e-4)
+    assert weights[5] == pytest.approx(0.0)  # uneligible score-0 stays at zero
+    assert weights[3] > 0  # eligible score-0 gets baseline
+    assert weights[3] < weights[0]  # baseline is far below any cubic-scored weight
+    assert pytest.approx(1.0, rel=1e-4) == float(np.sum(np.abs(weights)))
+
+
+def test_get_raw_weights_no_baseline_when_eligible_uids_none():
+    """When eligible_uids is None (legacy callers), score-0 UIDs stay at zero."""
+    vl = ValidatorLib()
+
+    scores = np.array([0.2, 0.5, 0.3, 0.0], dtype=float)
+    weights = vl.get_raw_weights(scores=scores, burn_uid=2, burn_rate=0.5)
+
+    assert weights[3] == pytest.approx(0.0)
+
+
 def test_get_raw_weights_distribution_with_smaller_burn():
     vl = ValidatorLib()
 


### PR DESCRIPTION
## Why

In `ValidatorLib.get_raw_weights`, any miner with `self.scores[uid] == 0` is excluded from the cubic weight distribution (line 217). Combined with how `update_scores` works, this means a miner stays at score 0 — and therefore gets zero weight from this validator — if any of the following happen:

- they've never been sampled by `get_random_uids`,
- they were sampled once and returned a bad/empty response,
- their hotkey was just replaced (scores reset to 0 in `resync_metagraph`).

There is no exploration path to bring a score-0 miner back into the weight distribution; recovery only happens via a future random sample that also returns a positive reward. On the live subnet, this contributes to a population of serving miners that earn nothing despite being healthy, because the chain consensus threshold needs >50% of stake voting non-zero for them.

## What this PR does

In `get_raw_weights`, eligible UIDs with score 0 now receive a tiny baseline weight (`5/65535 ≈ 7.6e-5`) before the cubic bucket is renormalized to `(1 - burn_rate)`. The baseline:

- is well above the chain's u16 quantization floor (`1/65535`),
- is **~13x smaller** than the lowest cubic-distributed weight (`y_min = 0.001`), so scored miners still receive strictly more weight than baselined miners,
- is gated by `check_uid_availability` (serving, not a validator, stake below `vpermit_tao_limit`) — matches the existing sampling filter in `get_random_uids`.

`set_weights` in `base/validator.py` builds the eligible-UID list from the current metagraph on every weight update and passes it into `get_raw_weights`. Burn allocation is unchanged.

## Impact

- Top earners: ~0.05% dilution per weight update (≈ 9 extra UIDs at ~4 u16 units each added to a ~72k total).
- Stuck miners: receive a registrable weight (~4 u16 units) instead of zero, giving them a path to non-zero consensus once enough live validators adopt the fix.
- Existing ordering is preserved: best scored miner > worst scored miner >> baselined miner > unweighted miner.

## Tests

- All 5 existing tests in `tests/unit/test_ValidatorLib_weights.py` still pass (the new behavior is opt-in via `eligible_uids`).
- Added `test_get_raw_weights_baseline_for_eligible_zero_score_uids` and `test_get_raw_weights_no_baseline_when_eligible_uids_none` to lock in the new behavior and the backward-compatible default.
