### PR TITLE
Feat - Add skills generation task

### DIFF
--- a/conversationgenome/__init__.py
+++ b/conversationgenome/__init__.py
@@ -15,7 +15,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "2.34.70"
+__version__ = "2.35.71"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/conversationgenome/llm/LlmLib.py
+++ b/conversationgenome/llm/LlmLib.py
@@ -207,6 +207,22 @@ class LlmLib(ABC):
             vectors = self.get_vector_embeddings_set(tags)
         return RawMetadata(tags=tags, vectors=vectors, success=True)
 
+    def skill_to_metadata(self, skill_markdown: str, generateEmbeddings=False, input_categories=None) -> RawMetadata|None:
+        prompt = prompt_manager.skill_to_metadata_prompt(skill_markdown)
+        response_content = self.basic_prompt(prompt)
+        if not isinstance(response_content, str):
+            print("Error: Unexpected response format. Content type:", type(response_content))
+            return None
+        tags = Utils.clean_tags(response_content.split(","))
+        if Utils.empty(tags):
+            print("No tags returned")
+            return None
+
+        vectors = None
+        if generateEmbeddings:
+            vectors = self.get_vector_embeddings_set(tags)
+        return RawMetadata(tags=tags, vectors=vectors, success=True)
+
     def enrichment_to_metadata(self, enrichment_content: str, generateEmbeddings=False, input_categories=None) -> RawMetadata|None:
         if input_categories and 'coding' in input_categories:
             prompt = prompt_manager.enrichment_to_metadata_coding_prompt(enrichment_content)

--- a/conversationgenome/llm/prompt_manager.py
+++ b/conversationgenome/llm/prompt_manager.py
@@ -60,6 +60,11 @@ class PromptManager:
             raise ValueError("website_content cannot be empty.")
         return self._get("website_to_metadata_coding.j2", website_content=website_content)
 
+    def skill_to_metadata_prompt(self, skill_markdown: str) -> str:
+        if not skill_markdown.strip():
+            raise ValueError("skill_markdown cannot be empty.")
+        return self._get("skill_to_metadata.j2", skill_markdown=skill_markdown)
+
     def enrichment_to_metadata_prompt(self, enrichment_content: str) -> str:
         if not enrichment_content.strip():
             raise ValueError("enrichment_content cannot be empty.")

--- a/conversationgenome/llm/prompts/skill_to_metadata.j2
+++ b/conversationgenome/llm/prompts/skill_to_metadata.j2
@@ -1,0 +1,27 @@
+<Role>
+You are an advanced AI assistant specializing in the analysis of LLM skill documents for metadata generation.
+</Role>
+
+<task>
+Your primary task is to analyze a given LLM skill document written in Markdown and identify the core topics, technologies, and capabilities it covers. A skill document typically includes a title, a description, guidance on when to use the skill, and instructions.
+</task>
+
+<instructions>
+1.  **Analyze the Skill:** Carefully read the skill document provided in the `skill_markdown` section.
+2.  **Extract key topics and capabilities:** Identify the most relevant topics, technologies, tools, and capabilities that describe what the skill does.
+3.  **Generate descriptive tags:** Create tags that capture the main themes, technologies, and key capabilities of the skill.
+4.  **Limit to most important:** Return at most 15 of the most important and relevant tags.
+5.  **Use lowercase:** All tags should be in lowercase.
+</instructions>
+
+<output_format>
+**Your response MUST be a single comma delimited list of tags in lowercase**. Do not include any text or explanations outside of the list. Do not include any special characters such as emoji.
+</output_format>
+
+<example_output>
+docx, parsing, python, document processing, file conversion
+</example_output>
+
+<skill_markdown>
+{{ skill_markdown }}
+</skill_markdown>

--- a/conversationgenome/task/SkillGenerationTask.py
+++ b/conversationgenome/task/SkillGenerationTask.py
@@ -1,0 +1,52 @@
+from typing import List
+from typing import Literal
+from typing import Optional
+from typing import Tuple
+
+import bittensor as bt
+from pydantic import BaseModel
+
+from conversationgenome.llm.llm_factory import get_llm_backend
+from conversationgenome.task.Task import Task
+
+
+class SkillTaskInputData(BaseModel):
+    window: List[Tuple[int, str]]
+    participants: Optional[List[str]] = None
+
+class SkillTaskInput(BaseModel):
+    guid: str
+    input_type: Literal["skill"]
+    data: SkillTaskInputData
+    input_categories: Optional[List[str]] = None
+
+
+class SkillGenerationTask(Task):
+    type: Literal["skill_generation"] = "skill_generation"
+    input: Optional[SkillTaskInput] = None
+
+    async def mine(self) -> dict[str, list]:
+        llml = get_llm_backend()
+
+        try:
+            all_tags = []
+
+            # The window contains the skill markdown line(s) written by the bundle's setup
+            for idx, (line_idx, content) in enumerate(self.input.data.window):
+                result = llml.skill_to_metadata(content, generateEmbeddings=False, input_categories=self.input.input_categories)
+
+                if result and result.tags:
+                    all_tags.append(result.tags)
+
+            # Combine all tags from the skill content
+            if all_tags:
+                combined_result = llml.combine_metadata_tags(all_tags, generateEmbeddings=False)
+                output = {"tags": combined_result.tags if combined_result else [], "vectors": combined_result.vectors if combined_result else None}
+            else:
+                output = {"tags": [], "vectors": None}
+
+        except Exception as e:
+            bt.logging.error(f"Error during mining: {e}")
+            raise e
+
+        return output

--- a/conversationgenome/task/task_factory.py
+++ b/conversationgenome/task/task_factory.py
@@ -25,11 +25,12 @@ def _get_task_adapter() -> TypeAdapter:
     from conversationgenome.task.WebpageMetadataGenerationTask import WebpageMetadataGenerationTask
     from conversationgenome.task.SurveyTaggingTask import SurveyTaggingTask
     from conversationgenome.task.NamedEntitiesExtrationTask import NamedEntitiesExtractionTask
+    from conversationgenome.task.SkillGenerationTask import SkillGenerationTask
 
-    
+
 
     TaskUnion = Annotated[
-        Union[ConversationTaggingTask, WebpageMetadataGenerationTask, SurveyTaggingTask, NamedEntitiesExtractionTask],
+        Union[ConversationTaggingTask, WebpageMetadataGenerationTask, SurveyTaggingTask, NamedEntitiesExtractionTask, SkillGenerationTask],
         Field(discriminator="type"),
     ]
     _TASK_ADAPTER = TypeAdapter(TaskUnion)

--- a/conversationgenome/task_bundle/SkillGenerationTaskBundle.py
+++ b/conversationgenome/task_bundle/SkillGenerationTaskBundle.py
@@ -1,0 +1,180 @@
+import json
+import uuid
+from typing import List
+from typing import Literal
+from typing import Optional
+from typing import Tuple
+
+import bittensor as bt
+from pydantic import BaseModel
+
+from conversationgenome.api.models.conversation_metadata import ConversationMetadata
+from conversationgenome.api.models.raw_metadata import RawMetadata
+from conversationgenome.ConfigLib import c
+
+from conversationgenome.llm.LlmLib import LlmLib
+from conversationgenome.llm.llm_factory import get_llm_backend
+from conversationgenome.scoring_mechanism.GroundTruthTagSimilarityScoringMechanism import (
+    GroundTruthTagSimilarityScoringMechanism,
+)
+from conversationgenome.task.Task import Task
+from conversationgenome.task.SkillGenerationTask import (
+    SkillTaskInput,
+)
+from conversationgenome.task.SkillGenerationTask import (
+    SkillTaskInputData,
+)
+from conversationgenome.task.SkillGenerationTask import (
+    SkillGenerationTask,
+)
+from conversationgenome.task_bundle.TaskBundle import TaskBundle
+from conversationgenome.utils.types import ForceStr
+from conversationgenome.utils.Utils import Utils
+
+
+class SkillInputData(BaseModel):
+    lines: List[Tuple[int, str]]
+
+    total: int
+    participants: List[str]
+    min_convo_windows: int = 0
+    indexed_windows: Optional[List[Tuple[int, List[Tuple[int, str]]]]] = None
+    prompt: str = (
+        "You are given an LLM skill document written in Markdown. Analyze the skill to identify the core topics, technologies, and capabilities it covers. Return only a flat list of tags in lowercase, separated by commas, with no explanations, formatting, or extra text. Example of required format: tag1, tag2, tag3"
+    )
+
+
+class SkillInput(BaseModel):
+    input_type: Literal["skill"]
+    guid: ForceStr
+    data: SkillInputData
+    input_categories: Optional[List[str]] = None
+    metadata: Optional[ConversationMetadata] = None
+
+    def trim_input(self) -> None:
+        max_lines = Utils._int(c.get('env', 'MAX_CONVO_LINES', 300))
+
+        if max_lines and len(self.data.lines) > max_lines:
+            self.data.lines = self.data.lines[:max_lines]
+            self.data.total = len(self.data.lines)
+
+
+class SkillGenerationTaskBundle(TaskBundle):
+    type: Literal["skill_generation"] = "skill_generation"
+    input: Optional[SkillInput] = None
+
+    def is_ready(self) -> bool:
+        if self.input.metadata is not None and self.input.data.indexed_windows is not None:
+            return True
+        return False
+
+    async def setup(self) -> None:
+        self.input.trim_input()
+        self._split_conversation_in_windows()
+        if not self.is_user_request:
+            self._enforce_minimum_convo_windows()
+        await self._generate_metadata()
+
+    def to_mining_tasks(self, number_of_tasks_per_bundle: int) -> List[Task]:
+        tasks = []
+        for _ in range(number_of_tasks_per_bundle):
+            random_id = str(uuid.uuid4())
+            task: SkillGenerationTask = SkillGenerationTask(
+                mode=self.mode,
+                api_version=self.api_version,
+                guid=random_id,
+                bundle_guid=self.guid,
+                type=self.type,
+                scoring_mechanism=self.scoring_mechanism,
+                input=SkillTaskInput(
+                    input_type=self.input.input_type,
+                    guid=self.input.guid,
+                    data=SkillTaskInputData(
+                        window=self.input.data.lines,
+                        participants=[]
+                    ),
+                    input_categories=self.input.input_categories
+                ),
+                prompt_chain=self.prompt_chain,
+                example_output=self.example_output,
+            )
+            tasks.append(task)
+
+        return tasks
+
+    def generate_result_logs(self, miner_result) -> str:
+        return (
+            f"tags: {len(miner_result.get('tags', [])) if isinstance(miner_result.get('tags'), (list, dict)) else 0} "
+            f"vector count: {len(miner_result.get('vectors', [])) if isinstance(miner_result.get('vectors'), (list, dict)) else 0} "
+            f"original tags: {len(miner_result.get('original_tags', [])) if isinstance(miner_result.get('original_tags'), (list, dict)) else 0}"
+        )
+
+    async def format_results(self, miner_result) -> str:
+        miner_result['original_tags'] = miner_result['tags']
+        # Clean and validate tags for duplicates or whitespace matches
+        llml = get_llm_backend()
+        miner_result['tags'] = llml.validate_tag_set(tags=miner_result['original_tags'])
+        miner_result['vectors'] = await self._get_vector_embeddings_set(llml=llml, tags=miner_result['tags'])
+        return miner_result
+
+    async def evaluate(self, miner_responses):
+        evaluator = GroundTruthTagSimilarityScoringMechanism()
+        return await evaluator.evaluate(self, miner_responses)
+
+    def _split_conversation_in_windows(self) -> None:
+        minLines = c.get("convo_window", "min_lines", 2)
+        maxLines = c.get("convo_window", "max_lines", 10)
+        overlapLines = c.get("convo_window", "overlap_lines", 2)
+
+        windows = Utils.split_overlap_array(self.input.data.lines, size=maxLines, overlap=overlapLines)
+        if len(windows) < 2:
+            windows = Utils.split_overlap_array(self.input.data.lines, size=minLines, overlap=overlapLines)
+
+        # TODO: Write convo windows into local database with full convo metadata
+        indexed_windows = []
+
+        for idx, window in enumerate(windows):
+            indexed_windows.append((idx, window))
+
+        self.input.data.indexed_windows = indexed_windows
+
+    def _enforce_minimum_convo_windows(self) -> None:
+        minimum_convo_windows = 1
+        if self.input.data.min_convo_windows is not None and self.input.data.min_convo_windows >= 0:
+            bt.logging.info(f"Change in minimum required convo windows from API from {minimum_convo_windows} to {self.input.data.min_convo_windows}.")
+            minimum_convo_windows = self.input.data.min_convo_windows
+
+        if len(self.input.data.indexed_windows) <= minimum_convo_windows:
+            bt.logging.info(f"Not enough convo windows -- only {len(self.input.data.indexed_windows)}. Passing.")
+            self.input.data.indexed_windows = []
+
+    async def _generate_metadata(self) -> None:
+        bt.logging.info(f"Generating metadata for skill generation")
+        parsed_json = json.loads(self.input.data.lines[0][1])
+        llml = get_llm_backend()
+
+        # Max 1000 characters from the skill markdown
+        skill_markdown = parsed_json['skill_markdown'][:1000]
+        skill_metadata = llml.skill_to_metadata(skill_markdown, input_categories=self.input.input_categories)
+        tags = [skill_metadata.tags]
+
+        # Rewrite input data to the plain skill markdown for the miner window
+        self.input.data.lines = [(0, skill_markdown)]
+
+        result: RawMetadata = llml.combine_metadata_tags(tags, generateEmbeddings=True)
+
+        if not result:
+            bt.logging.error(f"ERROR:2873226353. No metadata returned. Aborting.")
+            return
+
+        if not result.success:
+            bt.logging.error(f"ERROR:2873226354. Metadata failed: {result}. Aborting.")
+            return
+
+        self.input.metadata = ConversationMetadata(
+            tags=getattr(result, "tags", []),
+            vectors=getattr(result, "vectors", {}),
+        )
+
+    async def _get_vector_embeddings_set(self, llml: LlmLib, tags):
+        return llml.get_vector_embeddings_set(tags)

--- a/conversationgenome/task_bundle/task_bundle_factory.py
+++ b/conversationgenome/task_bundle/task_bundle_factory.py
@@ -19,9 +19,10 @@ def _get_task_bundle_adapter() -> TypeAdapter:
     from conversationgenome.task_bundle.WebpageMetadataGenerationTaskBundle import WebpageMetadataGenerationTaskBundle
     from conversationgenome.task_bundle.SurveyTaggingTaskBundle import SurveyTaggingTaskBundle
     from conversationgenome.task_bundle.NamedEntitiesExtractionTaskBundle import NamedEntitiesExtractionTaskBundle
+    from conversationgenome.task_bundle.SkillGenerationTaskBundle import SkillGenerationTaskBundle
 
     TaskBundleUnion = Annotated[
-        Union[ConversationTaggingTaskBundle, WebpageMetadataGenerationTaskBundle, SurveyTaggingTaskBundle, NamedEntitiesExtractionTaskBundle],
+        Union[ConversationTaggingTaskBundle, WebpageMetadataGenerationTaskBundle, SurveyTaggingTaskBundle, NamedEntitiesExtractionTaskBundle, SkillGenerationTaskBundle],
         Field(discriminator="type"),
     ]
     _TASK_BUNDLE_ADAPTER = TypeAdapter(TaskBundleUnion)

--- a/conversationgenome/utils/constants.py
+++ b/conversationgenome/utils/constants.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-TaskType = Literal["conversation_tagging", "webpage_metadata_generation", "survey_tagging"]
+TaskType = Literal["conversation_tagging", "webpage_metadata_generation", "survey_tagging", "skill_generation"]
 ScoringMechanismType = Literal["ground_truth_tag_similarity_scoring"]
 PENALTIES = {
     "no_both_tags": {

--- a/tests/mocks/DummyData.py
+++ b/tests/mocks/DummyData.py
@@ -400,6 +400,62 @@ class DummyData:
         }
 
     @staticmethod
+    def skill_generation_task_bundle_json():
+        skill_payload = json.dumps({
+            "seed": "Skill to parse .docx files",
+            "skill_markdown": "# Parse .docx\n\nInstructions to parse docx files with python.",
+            "enrichment": {},
+        })
+        return {
+            "mode": "validator",
+            "api_version": 1.4,
+            "type": "skill_generation",
+            "scoring_mechanism": "ground_truth_tag_similarity_scoring",
+            "input": {
+                "input_type": "skill",
+                "guid": DummyData.guid(),
+                "input_categories": None,
+                "data": {
+                    "lines": [(0, skill_payload)],
+                    "total": 1,
+                    "participants": ["UNKNOWN_SPEAKER"],
+                },
+                "metadata": DummyData.metadata()
+            },
+            "prompt_chain": [
+                {
+                    "step": 0,
+                    "id": "skill_001",
+                    "crc": 32132177,
+                    "title": "Infer descriptive tags for a skill document",
+                    "name": "infer_tags_for_skill",
+                    "description": "Returns descriptive tags summarizing the provided skill document.",
+                    "type": "inference",
+                    "input_path": "skill",
+                    "prompt_template": "You are given an LLM skill document written in Markdown. Analyze the skill to identify the core topics, technologies, and capabilities it covers. Return only a flat list of tags in lowercase, separated by commas, with no explanations, formatting, or extra text. Example of required format: tag1, tag2, tag3",
+                    "output_variable": "final_output",
+                    "output_type": "List[str]",
+                }
+            ],
+            "example_output": {"tags": ["docx", "parsing", "python"], "type": "List[str]"},
+            "errors": [],
+            "warnings": [],
+            "guid": DummyData.guid(),
+            "data_type": 1,
+        }
+
+    @staticmethod
+    def skill_generation_task_bundle() -> TaskBundle:
+        return try_parse_task_bundle(DummyData.skill_generation_task_bundle_json())
+
+    @staticmethod
+    def setup_skill_generation_task_bundle() -> TaskBundle:
+        task_bundle = try_parse_task_bundle(DummyData.skill_generation_task_bundle_json())
+        task_bundle.input.data.indexed_windows = DummyData.windows()
+        task_bundle.input.metadata = DummyData.metadata()
+        return task_bundle
+
+    @staticmethod
     def webpage_metadata_generation_task_bundle() -> TaskBundle:
         return try_parse_task_bundle(DummyData.webpage_metadata_generation_task_bundle_json())
 

--- a/tests/unit/test_SkillGenerationTask.py
+++ b/tests/unit/test_SkillGenerationTask.py
@@ -1,0 +1,102 @@
+from unittest.mock import MagicMock, Mock
+from unittest.mock import patch
+
+import pytest
+
+from conversationgenome.prompt_chain.PromptChainStep import PromptChainStep
+from conversationgenome.task.SkillGenerationTask import SkillGenerationTask, SkillTaskInput, SkillTaskInputData
+
+
+def _make_task(window):
+    return SkillGenerationTask(
+        mode="local",
+        api_version=1.4,
+        guid="test-guid",
+        bundle_guid="bundle-guid",
+        type="skill_generation",
+        input=SkillTaskInput(
+            guid="input-guid",
+            input_type="skill",
+            data=SkillTaskInputData(
+                window=window,
+                participants=[]
+            )
+        ),
+        prompt_chain=[PromptChainStep(
+            step=0,
+            id="skill_001",
+            crc=12345,
+            title="Infer tags",
+            name="infer_tags_for_skill",
+            description="Infer descriptive tags for a skill document",
+            type="inference",
+            input_path="skill",
+            prompt_template="Infer tags for the skill",
+            output_variable="final_output",
+            output_type="List[str]"
+        )]
+    )
+
+
+@pytest.mark.asyncio
+async def test_mine_returns_tags_and_vectors():
+    task = _make_task([(0, "# Parse .docx\n\nInstructions to parse docx files.")])
+
+    mock_llml = MagicMock()
+    skill_result = Mock()
+    skill_result.tags = ["docx", "parsing"]
+    mock_llml.skill_to_metadata = Mock(return_value=skill_result)
+
+    combined_result = Mock()
+    combined_result.tags = ["docx", "parsing"]
+    combined_result.vectors = {"docx": [0.1], "parsing": [0.2]}
+    mock_llml.combine_metadata_tags = Mock(return_value=combined_result)
+
+    with patch("conversationgenome.task.SkillGenerationTask.get_llm_backend", return_value=mock_llml):
+        result = await task.mine()
+
+    assert result["tags"] == ["docx", "parsing"]
+    assert result["vectors"] == {"docx": [0.1], "parsing": [0.2]}
+    mock_llml.skill_to_metadata.assert_called_once_with(
+        "# Parse .docx\n\nInstructions to parse docx files.", generateEmbeddings=False, input_categories=None
+    )
+    mock_llml.combine_metadata_tags.assert_called_once_with([["docx", "parsing"]], generateEmbeddings=False)
+
+
+@pytest.mark.asyncio
+async def test_mine_handles_empty_window():
+    task = _make_task([])
+    mock_llml = MagicMock()
+
+    with patch("conversationgenome.task.SkillGenerationTask.get_llm_backend", return_value=mock_llml):
+        result = await task.mine()
+
+    assert result["tags"] == []
+    assert result["vectors"] is None
+    mock_llml.skill_to_metadata.assert_not_called()
+    mock_llml.combine_metadata_tags.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mine_handles_none_result():
+    task = _make_task([(0, "Test skill content")])
+    mock_llml = MagicMock()
+    mock_llml.skill_to_metadata = Mock(return_value=None)
+    mock_llml.combine_metadata_tags = Mock(return_value=None)
+
+    with patch("conversationgenome.task.SkillGenerationTask.get_llm_backend", return_value=mock_llml):
+        result = await task.mine()
+
+    assert result["tags"] == []
+    assert result["vectors"] is None
+
+
+@pytest.mark.asyncio
+async def test_mine_raises_on_llm_exception():
+    task = _make_task([(0, "Test skill content")])
+    mock_llml = MagicMock()
+    mock_llml.skill_to_metadata = Mock(side_effect=Exception("LLM Error"))
+
+    with patch("conversationgenome.task.SkillGenerationTask.get_llm_backend", return_value=mock_llml):
+        with pytest.raises(Exception, match="LLM Error"):
+            await task.mine()

--- a/tests/unit/test_SkillGenerationTaskBundle.py
+++ b/tests/unit/test_SkillGenerationTaskBundle.py
@@ -1,0 +1,190 @@
+from unittest.mock import AsyncMock, Mock, patch
+import json
+import pytest
+from conversationgenome.task_bundle.SkillGenerationTaskBundle import SkillGenerationTaskBundle
+from tests.mocks.DummyData import DummyData
+
+
+def test_is_ready_false_when_no_metadata():
+    bundle = DummyData.skill_generation_task_bundle()
+    bundle.input.metadata = None
+    assert not bundle.is_ready()
+
+
+def test_is_ready_false_when_no_indexed_windows():
+    bundle = DummyData.skill_generation_task_bundle()
+    bundle.input.data.indexed_windows = None
+    assert not bundle.is_ready()
+
+
+def test_is_ready_true_when_metadata_and_indexed_windows():
+    bundle = DummyData.setup_skill_generation_task_bundle()
+    assert bundle.is_ready()
+
+
+@pytest.mark.asyncio
+async def test_setup_calls_trim_input_and_split_and_generate():
+    bundle = DummyData.skill_generation_task_bundle()
+    with patch.object(bundle, '_split_conversation_in_windows') as mock_split, \
+         patch.object(bundle, '_enforce_minimum_convo_windows') as mock_enforce, \
+         patch.object(bundle, '_generate_metadata') as mock_generate:
+
+        await bundle.setup()
+
+        mock_split.assert_called_once()
+        mock_enforce.assert_called_once()
+        mock_generate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_user_request_skips_min_windows():
+    bundle = DummyData.skill_generation_task_bundle()
+    bundle.is_user_request = True
+    with patch.object(bundle, '_split_conversation_in_windows') as mock_split, \
+         patch.object(bundle, '_enforce_minimum_convo_windows') as mock_enforce, \
+         patch.object(bundle, '_generate_metadata') as mock_generate:
+
+        await bundle.setup()
+
+        mock_split.assert_called_once()
+        mock_enforce.assert_not_called()
+        mock_generate.assert_called_once()
+
+
+def test_to_mining_tasks_creates_tasks():
+    bundle = DummyData.setup_skill_generation_task_bundle()
+    tasks = bundle.to_mining_tasks(2)
+    assert len(tasks) == 2
+    for task in tasks:
+        assert task.type == "skill_generation"
+        assert task.bundle_guid == bundle.guid
+        assert task.input.input_type == "skill"
+
+
+def test_generate_result_logs_counts_tags_and_vectors():
+    bundle = DummyData.setup_skill_generation_task_bundle()
+    miner_result = {"tags": ["tag1", "tag2"], "vectors": {"tag1": [0.1]}, "original_tags": ["tag1", "tag2", "tag3"]}
+    log = bundle.generate_result_logs(miner_result)
+    assert "tags: 2" in log
+    assert "vector count: 1" in log
+    assert "original tags: 3" in log
+
+
+@pytest.mark.asyncio
+async def test_format_results_validates_and_embeds_tags():
+    bundle = DummyData.setup_skill_generation_task_bundle()
+    miner_result = {"tags": ["tag1", "tag2"]}
+    with patch('conversationgenome.task_bundle.SkillGenerationTaskBundle.get_llm_backend') as mock_llm_factory:
+        mock_llm = Mock()
+        mock_llm.validate_tag_set.return_value = ["tag1", "tag2"]
+        mock_llm_factory.return_value = mock_llm
+        with patch.object(bundle, '_get_vector_embeddings_set', AsyncMock(return_value={"tag1": [0.1], "tag2": [0.2]})):
+            result = await bundle.format_results(miner_result)
+    assert result["original_tags"] == ["tag1", "tag2"]
+    assert result["tags"] == ["tag1", "tag2"]
+    assert result["vectors"] == {"tag1": [0.1], "tag2": [0.2]}
+
+
+@pytest.mark.asyncio
+async def test_evaluate_calls_ground_truth_scoring():
+    bundle = DummyData.setup_skill_generation_task_bundle()
+    with patch('conversationgenome.task_bundle.SkillGenerationTaskBundle.GroundTruthTagSimilarityScoringMechanism') as mock_mech:
+        mock_eval = AsyncMock(return_value="score")
+        mock_mech.return_value.evaluate = mock_eval
+        result = await bundle.evaluate(["response"])
+    assert result == "score"
+
+
+def test_enforce_minimum_convo_windows_sets_empty_when_below_minimum():
+    bundle = DummyData.setup_skill_generation_task_bundle()
+    bundle.input.data.min_convo_windows = 3
+    bundle.input.data.indexed_windows = [(0, []), (1, [])]  # Only 2 windows
+    bundle._enforce_minimum_convo_windows()
+    assert bundle.input.data.indexed_windows == []
+
+
+@pytest.mark.asyncio
+async def test_generate_metadata_calls_llm_and_sets_metadata():
+    bundle = DummyData.skill_generation_task_bundle()
+    bundle.input.data.lines = [(0, json.dumps({
+        "seed": "Skill to parse docx",
+        "skill_markdown": "# Parse docx\n\nInstructions.",
+        "enrichment": {},
+    }))]
+
+    with patch('conversationgenome.task_bundle.SkillGenerationTaskBundle.get_llm_backend') as mock_llm_factory:
+        mock_llm = Mock()
+
+        skill_result = Mock()
+        skill_result.tags = ["docx", "parsing"]
+        mock_llm.skill_to_metadata.return_value = skill_result
+
+        combine_result = Mock()
+        combine_result.success = True
+        combine_result.tags = ["docx", "parsing"]
+        combine_result.vectors = {"docx": {"vectors": [0.1]}}
+        mock_llm.combine_metadata_tags.return_value = combine_result
+
+        mock_llm_factory.return_value = mock_llm
+
+        await bundle._generate_metadata()
+
+        assert bundle.input.metadata.tags == ["docx", "parsing"]
+        assert bundle.input.metadata.vectors == {"docx": {"vectors": [0.1]}}
+
+        # skill_markdown is tagged; seed is ignored
+        mock_llm.skill_to_metadata.assert_called_once_with("# Parse docx\n\nInstructions.", input_categories=None)
+        mock_llm.combine_metadata_tags.assert_called_once_with([["docx", "parsing"]], generateEmbeddings=True)
+
+        # input lines rewritten to the plain skill markdown for the miner window
+        assert bundle.input.data.lines == [(0, "# Parse docx\n\nInstructions.")]
+
+
+@pytest.mark.asyncio
+async def test_generate_metadata_handles_failure():
+    bundle = DummyData.skill_generation_task_bundle()
+    bundle.input.data.lines = [(0, json.dumps({"seed": "s", "skill_markdown": "md", "enrichment": {}}))]
+    bundle.input.metadata = None
+    with patch('conversationgenome.task_bundle.SkillGenerationTaskBundle.get_llm_backend') as mock_llm_factory:
+        mock_llm = Mock()
+        skill_result = Mock()
+        skill_result.tags = ["md"]
+        mock_llm.skill_to_metadata.return_value = skill_result
+
+        combine_result = Mock()
+        combine_result.success = False
+        mock_llm.combine_metadata_tags.return_value = combine_result
+
+        mock_llm_factory.return_value = mock_llm
+
+        await bundle._generate_metadata()
+
+        assert bundle.input.metadata is None
+
+
+@pytest.mark.asyncio
+async def test_generate_metadata_handles_no_result():
+    bundle = DummyData.skill_generation_task_bundle()
+    bundle.input.data.lines = [(0, json.dumps({"seed": "s", "skill_markdown": "md", "enrichment": {}}))]
+    bundle.input.metadata = None
+    with patch('conversationgenome.task_bundle.SkillGenerationTaskBundle.get_llm_backend') as mock_llm_factory:
+        mock_llm = Mock()
+        skill_result = Mock()
+        skill_result.tags = ["md"]
+        mock_llm.skill_to_metadata.return_value = skill_result
+        mock_llm.combine_metadata_tags.return_value = None
+
+        mock_llm_factory.return_value = mock_llm
+
+        await bundle._generate_metadata()
+
+        assert bundle.input.metadata is None
+
+
+@pytest.mark.asyncio
+async def test_get_vector_embeddings_set_calls_llm():
+    bundle = DummyData.setup_skill_generation_task_bundle()
+    mock_llm = Mock()
+    mock_llm.get_vector_embeddings_set.return_value = {"tag": [0.1]}
+    result = await bundle._get_vector_embeddings_set(llml=mock_llm, tags=["tag"])
+    assert result == {"tag": [0.1]}


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                       
  - Adds a new skill_generation task type: SkillGenerationTask mines skill-markdown windows through the LLM to produce tags/vectors, backed by a new SkillGenerationTaskBundle and a dedicated skill_to_metadata prompt.                                                                                               
  - Wires the new task/bundle into task_factory and task_bundle_factory, extends LlmLib with skill_to_metadata support, and updates prompt_manager and constants accordingly.                                                                                                                                          
  - Adds unit tests (test_SkillGenerationTask.py, test_SkillGenerationTaskBundle.py) plus supporting mocks in DummyData.                                                                                                                                                                                               
  - Bumps the package version in conversationgenome/__init__.py.       