### PR TITLE
Update Bittensor version

### DIFF
--- a/conversationgenome/__init__.py
+++ b/conversationgenome/__init__.py
@@ -15,7 +15,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "2.35.71"
+__version__ = "2.36.72"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/conversationgenome/analytics/WandbLib.py
+++ b/conversationgenome/analytics/WandbLib.py
@@ -64,8 +64,8 @@ class WandbLib:
         if config:
             # initialize data:
             try:
-                wallet = bt.wallet(config=config)
-                subtensor = bt.subtensor(config=config)
+                wallet = bt.Wallet(config=config)
+                subtensor = bt.Subtensor(config=config)
                 netuid = config.netuid
                 metagraph = subtensor.metagraph(config.netuid)
                 my_hotkey = wallet.hotkey.ss58_address

--- a/conversationgenome/base/miner.py
+++ b/conversationgenome/base/miner.py
@@ -55,7 +55,7 @@ class BaseMinerNeuron(BaseNeuron):
             )
 
         # The axon handles request processing, allowing validators to send this miner requests.
-        self.axon = bt.axon(wallet=self.wallet, config=self.config)
+        self.axon = bt.Axon(wallet=self.wallet, config=self.config)
 
         # Attach determiners which functions are called when servicing a request.
         bt.logging.info(f"Attaching forward function to miner axon.")

--- a/conversationgenome/base/neuron.py
+++ b/conversationgenome/base/neuron.py
@@ -50,9 +50,9 @@ class BaseNeuron(ABC):
     def config(cls):
         return config(cls)
 
-    subtensor: "bt.subtensor"
-    wallet: "bt.wallet"
-    metagraph: "bt.metagraph"
+    subtensor: "bt.Subtensor"
+    wallet: "bt.Wallet"
+    metagraph: "bt.Metagraph"
     spec_version=0
     if load_spec_version:
         spec_version: int = load_spec_version
@@ -90,8 +90,8 @@ class BaseNeuron(ABC):
                 self.config.netuid, subtensor=self.subtensor
             )
         else:
-            self.wallet = bt.wallet(config=self.config)
-            self.subtensor = bt.subtensor(config=self.config)
+            self.wallet = bt.Wallet(config=self.config)
+            self.subtensor = bt.Subtensor(config=self.config)
             self.metagraph = self.subtensor.metagraph(self.config.netuid)
 
         bt.logging.info(f"Wallet: {self.wallet}")

--- a/conversationgenome/base/validator.py
+++ b/conversationgenome/base/validator.py
@@ -63,7 +63,7 @@ class BaseValidatorNeuron(BaseNeuron):
         if self.config.mock:
             self.dendrite = MockDendrite(wallet=self.wallet)
         else:
-            self.dendrite = bt.dendrite(wallet=self.wallet)
+            self.dendrite = bt.Dendrite(wallet=self.wallet)
         bt.logging.info(f"Dendrite: {self.dendrite}")
 
         # Install a log filter to redact miner IP addresses from bittensor's
@@ -138,7 +138,7 @@ class BaseValidatorNeuron(BaseNeuron):
 
         bt.logging.info("serving ip to chain...")
         try:
-            self.axon = bt.axon(wallet=self.wallet, config=self.config)
+            self.axon = bt.Axon(wallet=self.wallet, config=self.config)
 
             try:
                 self.subtensor.serve_axon(

--- a/conversationgenome/commitment/commitment.py
+++ b/conversationgenome/commitment/commitment.py
@@ -65,8 +65,16 @@ def decrypt_endpoint(ciphertext: bytes, private_key_bytes: bytes, expected_hotke
 
 
 def publish_commitment(subtensor, wallet, netuid: int, ciphertext: bytes) -> bool:
-    """Publish encrypted endpoint ciphertext on-chain via publish_metadata."""
-    from bittensor.core.extrinsics.serving import publish_metadata
+    """Publish encrypted endpoint ciphertext on-chain via publish_metadata.
+
+    bittensor 10.x renamed publish_metadata → publish_metadata_extrinsic; the
+    call signature is unchanged, so we import whichever the installed version
+    exposes (10.x first, 9.x fallback).
+    """
+    try:
+        from bittensor.core.extrinsics.serving import publish_metadata_extrinsic as publish_metadata
+    except ImportError:
+        from bittensor.core.extrinsics.serving import publish_metadata
 
     try:
         publish_metadata(
@@ -89,11 +97,18 @@ def publish_commitment(subtensor, wallet, netuid: int, ciphertext: bytes) -> boo
 
 
 def read_commitment(subtensor, netuid: int, hotkey_ss58: str) -> Optional[bytes]:
-    """Read a single miner's encrypted commitment from chain."""
-    from bittensor.core.extrinsics.serving import get_metadata
+    """Read a single miner's encrypted commitment from chain.
 
+    Queries the Commitments.CommitmentOf storage directly. This replaces the
+    old bittensor.core.extrinsics.serving.get_metadata helper, which was
+    removed in bittensor 10.x; the direct query works on both 9.x and 10.x.
+    """
     try:
-        metadata = get_metadata(subtensor, netuid, hotkey_ss58)
+        metadata = subtensor.substrate.query(
+            module="Commitments",
+            storage_function="CommitmentOf",
+            params=[netuid, hotkey_ss58],
+        )
         if metadata is None:
             return None
         commitment = metadata["info"]["fields"][0][0]

--- a/conversationgenome/commitment/commitment.py
+++ b/conversationgenome/commitment/commitment.py
@@ -111,20 +111,47 @@ def read_commitment(subtensor, netuid: int, hotkey_ss58: str) -> Optional[bytes]
         )
         if metadata is None:
             return None
-        commitment = metadata["info"]["fields"][0][0]
-        raw_key = next(iter(commitment.keys()))
-        return bytes(commitment[raw_key][0])
+        return _extract_ciphertext(metadata)
     except Exception as e:
         bt.logging.debug(f"Could not read commitment for {hotkey_ss58}: {e}")
         return None
 
 
+def _raw_field_to_bytes(value) -> Optional[bytes]:
+    """Normalize a Commitments Raw{N} field value to bytes.
+
+    The on-chain value decodes differently across substrate stacks:
+      - bittensor 10.x (async-substrate-interface 2.x): a hex string '0x...'
+      - bittensor 9.x: a nested byte list, e.g. [[b0, b1, ...]]
+      - occasionally already bytes
+    """
+    if isinstance(value, str):
+        return bytes.fromhex(value[2:] if value.startswith("0x") else value)
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    if isinstance(value, (list, tuple)):
+        inner = value
+        if len(value) == 1 and isinstance(value[0], (list, tuple, bytes, bytearray, str)):
+            inner = value[0]
+        if isinstance(inner, str):
+            return bytes.fromhex(inner[2:] if inner.startswith("0x") else inner)
+        return bytes(inner)
+    return None
+
+
 def _extract_ciphertext(commitment_data) -> Optional[bytes]:
-    """Extract ciphertext bytes from a commitment data structure."""
+    """Extract ciphertext bytes from a commitment data structure.
+
+    Handles both the bittensor 9.x shape (fields -> [[{RawN: [[...]]}]]) and the
+    10.x shape (fields -> [{RawN: '0x...'}]), and unwraps ScaleObj via .value.
+    """
     try:
-        commitment = commitment_data["info"]["fields"][0][0]
-        raw_key = next(iter(commitment.keys()))
-        return bytes(commitment[raw_key][0])
+        data = commitment_data.value if hasattr(commitment_data, "value") else commitment_data
+        entry = data["info"]["fields"][0]
+        if isinstance(entry, (list, tuple)):
+            entry = entry[0]
+        raw_key = next(iter(entry.keys()))
+        return _raw_field_to_bytes(entry[raw_key])
     except Exception:
         return None
 
@@ -174,7 +201,8 @@ def read_all_commitments(
         if hotkey_str not in hotkey_set:
             continue
 
-        block = commitment_data.get("block", 0) if hasattr(commitment_data, "get") else 0
+        data = commitment_data.value if hasattr(commitment_data, "value") else commitment_data
+        block = data.get("block", 0) if hasattr(data, "get") else 0
 
         # If block hasn't changed, reuse cached decryption
         if hotkey_str in cache and cache[hotkey_str][0] == block:

--- a/conversationgenome/mock/mock.py
+++ b/conversationgenome/mock/mock.py
@@ -35,7 +35,7 @@ class MockSubtensor(bt.MockSubtensor):
             )
 
 
-class MockMetagraph(bt.metagraph):
+class MockMetagraph(bt.Metagraph):
     def __init__(self, netuid=1, network="mock", subtensor=None):
         super().__init__(netuid=netuid, network=network, sync=False)
 
@@ -51,7 +51,7 @@ class MockMetagraph(bt.metagraph):
         bt.logging.info(f"Axons: {self.axons}")
 
 
-class MockDendrite(bt.dendrite):
+class MockDendrite(bt.Dendrite):
     """
     Replaces a real bittensor network request with a mock request that just returns some static response for all axons that are passed and adds some random delay.
     """
@@ -61,7 +61,7 @@ class MockDendrite(bt.dendrite):
 
     async def forward(
         self,
-        axons: List[bt.axon],
+        axons: List[bt.Axon],
         synapse: bt.Synapse = bt.Synapse(),
         timeout: float = 12,
         deserialize: bool = True,

--- a/conversationgenome/utils/config.py
+++ b/conversationgenome/utils/config.py
@@ -249,9 +249,9 @@ def config(cls):
     Returns the configuration object specific to this miner or validator after adding relevant arguments.
     """
     parser = argparse.ArgumentParser()
-    bt.wallet.add_args(parser)
-    bt.subtensor.add_args(parser)
+    bt.Wallet.add_args(parser)
+    bt.Subtensor.add_args(parser)
     bt.logging.add_args(parser)
-    bt.axon.add_args(parser)
+    bt.Axon.add_args(parser)
     cls.add_args(parser)
     return bt.config(parser)

--- a/conversationgenome/utils/config.py
+++ b/conversationgenome/utils/config.py
@@ -254,4 +254,4 @@ def config(cls):
     bt.logging.add_args(parser)
     bt.Axon.add_args(parser)
     cls.add_args(parser)
-    return bt.config(parser)
+    return bt.Config(parser)

--- a/conversationgenome/utils/uids.py
+++ b/conversationgenome/utils/uids.py
@@ -15,11 +15,11 @@ from typing import List
 
 
 def check_uid_availability(
-    metagraph: "bt.metagraph.Metagraph", uid: int, vpermit_tao_limit: int
+    metagraph: "bt.Metagraph", uid: int, vpermit_tao_limit: int
 ) -> bool:
     """Check if uid is available. The UID should be available if it is serving and has less than vpermit_tao_limit stake
     Args:
-        metagraph (:obj: bt.metagraph.Metagraph): Metagraph object
+        metagraph (:obj: bt.Metagraph): Metagraph object
         uid (int): uid to be checked
         vpermit_tao_limit (int): Validator permit tao limit
     Returns:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ pypdf==6.6.0
 pydantic==2.7.1
 typing-extensions==4.8.0
 httpx==0.27.2
-async-substrate-interface==1.6.4
+async-substrate-interface==2.0.2
 pynacl==1.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies
 python-dotenv==1.0.1
-bittensor>=10.3.0
+bittensor==10.3.0
 torch==2.1.1
 openai==1.30.3
 loguru==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies
 python-dotenv==1.0.1
-bittensor==9.0.0
+bittensor>=10.3.0
 torch==2.1.1
 openai==1.30.3
 loguru==0.7.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 # Core dependencies
 python-dotenv==1.0.1
-bittensor==9.0.0
+bittensor==10.3.0
 torch==2.1.1
 openai==1.30.3
 loguru==0.7.0
@@ -14,5 +14,5 @@ pytest-asyncio
 pydantic==2.7.1
 typing-extensions==4.8.0
 httpx==0.27.2
-async-substrate-interface==1.6.4
+async-substrate-interface==2.0.2
 pynacl==1.6.2

--- a/scripts/get_validator_api_key.py
+++ b/scripts/get_validator_api_key.py
@@ -55,7 +55,7 @@ class ReadyAiApiLib():
 
 
     def get_validator_info(self, ss58_coldkey=None, ss58_hotkey=None, netuid=1, verbose=False):
-        subnet = bt.metagraph(netuid, network=self.network)
+        subnet = bt.Metagraph(netuid, network=self.network)
         if ss58_coldkey and not ss58_coldkey in subnet.coldkeys:
             print(f"{RED}Coldkey {ss58_coldkey} not registered on subnet. Aborting.{COLOR_END}")
             if self.verbose or verbose:
@@ -211,7 +211,7 @@ class ReadyAiApiLib():
 
 
     def get_coldkey_object(self, name, path):
-        wallet = bt.wallet(name=name, path=path)
+        wallet = bt.Wallet(name=name, path=path)
         try:
             coldkey = wallet.get_coldkey()
         except Exception as e:
@@ -220,7 +220,7 @@ class ReadyAiApiLib():
         return coldkey
 
     def get_hotkey_object(self, coldkey_name, hotkey_name, path):
-        wallet = bt.wallet(name=coldkey_name, hotkey=hotkey_name, path=path)
+        wallet = bt.Wallet(name=coldkey_name, hotkey=hotkey_name, path=path)
         try:
             hotkey = wallet.get_hotkey()
         except Exception as e:

--- a/tests/test_full_loop.py
+++ b/tests/test_full_loop.py
@@ -24,8 +24,8 @@ default_prompt_value = "Analyze conversation in terms of topic interests of the 
 
 @pytest.fixture
 def validator_with_mock_metagraph():
-    with patch("conversationgenome.base.neuron.MockMetagraph") as mock_metagraph_class, patch("bittensor.subtensor") as mock_subtensor_class, patch(
-        "bittensor.wallet"
+    with patch("conversationgenome.base.neuron.MockMetagraph") as mock_metagraph_class, patch("bittensor.Subtensor") as mock_subtensor_class, patch(
+        "bittensor.Wallet"
     ) as mock_wallet_class:
 
         # Wallet

--- a/tests/test_vali_loop.py
+++ b/tests/test_vali_loop.py
@@ -18,8 +18,8 @@ from itertools import cycle
 
 @pytest.fixture
 def validator_with_mock_metagraph():
-    with patch("conversationgenome.base.neuron.MockMetagraph") as mock_metagraph_class, patch("bittensor.subtensor") as mock_subtensor_class, patch(
-        "bittensor.wallet"
+    with patch("conversationgenome.base.neuron.MockMetagraph") as mock_metagraph_class, patch("bittensor.Subtensor") as mock_subtensor_class, patch(
+        "bittensor.Wallet"
     ) as mock_wallet_class:
         c.set('env', 'CONVO_QUALITY_THRESHOLD', 1)  # Set low quality threshold for testing
 

--- a/tests/test_weight_distro.py
+++ b/tests/test_weight_distro.py
@@ -44,7 +44,7 @@ def get_tied_indices(original_scores_list):
     return tied_indices
 
 def get_real_weights():
-    metagraph = bt.metagraph(33, lite = False)
+    metagraph = bt.Metagraph(33, lite = False)
     otf_weights = metagraph.W[63]
 
     stakes = metagraph.S

--- a/tests/unit/test_commitment.py
+++ b/tests/unit/test_commitment.py
@@ -144,6 +144,18 @@ class TestReadCommitment:
         result = read_commitment(subtensor, 138, "5FakeHotkey")
         assert result == ct
 
+    def test_reads_ciphertext_from_bt10_hex_metadata(self):
+        # bittensor 10.x / async-substrate-interface 2.x returns fields as
+        # [{RawN: '0x...'}] (single dict, hex string) rather than [[{RawN: [[...]]}]]
+        pub, _ = _generate_keypair()
+        ct = encrypt_endpoint("10.0.0.1", 9000, pub)
+        metadata = {"info": {"fields": [{f"Raw{len(ct)}": "0x" + ct.hex()}]}}
+
+        subtensor = MagicMock()
+        subtensor.substrate.query.return_value = metadata
+        result = read_commitment(subtensor, 138, "5FakeHotkey")
+        assert result == ct
+
     def test_returns_none_when_no_metadata(self):
         subtensor = MagicMock()
         subtensor.substrate.query.return_value = None
@@ -163,6 +175,23 @@ class TestReadAllCommitments:
     @staticmethod
     def _make_commitment_data(ciphertext, block=100):
         return {"block": block, "info": {"fields": [[{f"Raw{len(ciphertext)}": [list(ciphertext)]}]]}}
+
+    @staticmethod
+    def _make_bt10_commitment_data(ciphertext, block=100):
+        # bittensor 10.x shape: fields -> [{RawN: '0x...'}]
+        return {"block": block, "info": {"fields": [{f"Raw{len(ciphertext)}": "0x" + ciphertext.hex()}]}}
+
+    def test_decrypts_bt10_hex_format(self):
+        pub, priv = _generate_keypair()
+        ct = encrypt_endpoint("10.0.0.5", 8091, pub, hotkey="hk0")
+
+        subtensor = MagicMock()
+        subtensor.query_map.return_value = [("hk0", self._make_bt10_commitment_data(ct, block=42))]
+
+        endpoints, cache = read_all_commitments(subtensor, 138, ["hk0"], priv)
+
+        assert endpoints["hk0"] == ("10.0.0.5", 8091)
+        assert cache["hk0"][0] == 42
 
     def test_decrypts_all_available(self):
         pub, priv = _generate_keypair()

--- a/tests/unit/test_commitment.py
+++ b/tests/unit/test_commitment.py
@@ -90,7 +90,7 @@ class TestEncryptDecrypt:
 class TestPublishCommitment:
     def test_success(self):
         with patch(
-            "bittensor.core.extrinsics.serving.publish_metadata"
+            "bittensor.core.extrinsics.serving.publish_metadata_extrinsic"
         ) as mock_pub:
             result = publish_commitment(
                 subtensor=MagicMock(),
@@ -106,7 +106,7 @@ class TestPublishCommitment:
 
     def test_rate_limit_returns_false(self):
         with patch(
-            "bittensor.core.extrinsics.serving.publish_metadata",
+            "bittensor.core.extrinsics.serving.publish_metadata_extrinsic",
             side_effect=Exception("rate limit exceeded"),
         ):
             result = publish_commitment(
@@ -119,7 +119,7 @@ class TestPublishCommitment:
 
     def test_generic_error_returns_false(self):
         with patch(
-            "bittensor.core.extrinsics.serving.publish_metadata",
+            "bittensor.core.extrinsics.serving.publish_metadata_extrinsic",
             side_effect=Exception("something broke"),
         ):
             result = publish_commitment(
@@ -139,28 +139,22 @@ class TestReadCommitment:
         ct = encrypt_endpoint("10.0.0.1", 9000, pub)
         metadata = {"info": {"fields": [[{"Raw69": [list(ct)]}]]}}
 
-        with patch(
-            "bittensor.core.extrinsics.serving.get_metadata",
-            return_value=metadata,
-        ):
-            result = read_commitment(MagicMock(), 138, "5FakeHotkey")
-            assert result == ct
+        subtensor = MagicMock()
+        subtensor.substrate.query.return_value = metadata
+        result = read_commitment(subtensor, 138, "5FakeHotkey")
+        assert result == ct
 
     def test_returns_none_when_no_metadata(self):
-        with patch(
-            "bittensor.core.extrinsics.serving.get_metadata",
-            return_value=None,
-        ):
-            result = read_commitment(MagicMock(), 138, "5FakeHotkey")
-            assert result is None
+        subtensor = MagicMock()
+        subtensor.substrate.query.return_value = None
+        result = read_commitment(subtensor, 138, "5FakeHotkey")
+        assert result is None
 
     def test_returns_none_on_exception(self):
-        with patch(
-            "bittensor.core.extrinsics.serving.get_metadata",
-            side_effect=Exception("network error"),
-        ):
-            result = read_commitment(MagicMock(), 138, "5FakeHotkey")
-            assert result is None
+        subtensor = MagicMock()
+        subtensor.substrate.query.side_effect = Exception("network error")
+        result = read_commitment(subtensor, 138, "5FakeHotkey")
+        assert result is None
 
 
 # ── read_all_commitments ─────────────────────────────────────────────

--- a/tests/unit/test_commitment.py
+++ b/tests/unit/test_commitment.py
@@ -13,6 +13,17 @@ from conversationgenome.commitment.commitment import (
     read_commitment,
 )
 
+# publish_commitment imports publish_metadata_extrinsic on bittensor 10.x and
+# falls back to publish_metadata on 9.x. Patch whichever the installed version
+# actually exposes so these tests pass on either (matches the code's fallback).
+import bittensor.core.extrinsics.serving as _bt_serving
+
+_PUBLISH_TARGET = "bittensor.core.extrinsics.serving." + (
+    "publish_metadata_extrinsic"
+    if hasattr(_bt_serving, "publish_metadata_extrinsic")
+    else "publish_metadata"
+)
+
 
 # ── helpers ──────────────────────────────────────────────────────────
 
@@ -89,9 +100,7 @@ class TestEncryptDecrypt:
 
 class TestPublishCommitment:
     def test_success(self):
-        with patch(
-            "bittensor.core.extrinsics.serving.publish_metadata_extrinsic"
-        ) as mock_pub:
+        with patch(_PUBLISH_TARGET) as mock_pub:
             result = publish_commitment(
                 subtensor=MagicMock(),
                 wallet=MagicMock(),
@@ -105,10 +114,7 @@ class TestPublishCommitment:
             assert call_kwargs["data"] == b"\x01" * 69
 
     def test_rate_limit_returns_false(self):
-        with patch(
-            "bittensor.core.extrinsics.serving.publish_metadata_extrinsic",
-            side_effect=Exception("rate limit exceeded"),
-        ):
+        with patch(_PUBLISH_TARGET, side_effect=Exception("rate limit exceeded")):
             result = publish_commitment(
                 subtensor=MagicMock(),
                 wallet=MagicMock(),
@@ -118,10 +124,7 @@ class TestPublishCommitment:
             assert result is False
 
     def test_generic_error_returns_false(self):
-        with patch(
-            "bittensor.core.extrinsics.serving.publish_metadata_extrinsic",
-            side_effect=Exception("something broke"),
-        ):
+        with patch(_PUBLISH_TARGET, side_effect=Exception("something broke")):
             result = publish_commitment(
                 subtensor=MagicMock(),
                 wallet=MagicMock(),


### PR DESCRIPTION
Upgraded the codebase from bittensor 9 → 10.3.0. bittensor 10 renamed/removed several APIs, which broke the on-chain commitment system (how validators discover miner endpoints).