### PR TITLE
[Fix] Improve validator stability and prevent miner timeout

### DIFF
--- a/conversationgenome/__init__.py
+++ b/conversationgenome/__init__.py
@@ -15,7 +15,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "2.37.74"
+__version__ = "2.38.75"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/conversationgenome/api/ApiLib.py
+++ b/conversationgenome/api/ApiLib.py
@@ -25,7 +25,7 @@ except:
 class ApiLib:
     verbose = False
 
-    async def reserve_task_bundle(self, hotkey, api_key=None) -> TaskBundle:
+    async def reserve_task_bundle(self, hotkey, netuid, api_key=None) -> TaskBundle:
         headers = {
             "Accept": "application/json",
             "Accept-Language": "en_US",
@@ -39,7 +39,7 @@ class ApiLib:
         read_host_port = c.get('env', 'CGP_API_READ_PORT', '443')
         http_timeout = Utils._float(c.get('env', 'HTTP_TIMEOUT', 60))
         options_str = c.get('env', 'CGP_API_OPTIONS', '')
-        url = f"{read_host_url}:{read_host_port}/api/v1/conversation/reserve?cgp_version={CGP_VERSION}"
+        url = f"{read_host_url}:{read_host_port}/api/v1/conversation/reserve?cgp_version={CGP_VERSION}&netuid={netuid}"
 
         if len(options_str) > 0:
             options = options_str.split(",")
@@ -67,7 +67,7 @@ class ApiLib:
 
         return task_bundle
 
-    async def put_task_data(self, id, json_data) -> bool:
+    async def put_task_data(self, id, json_data, api_key=None) -> bool:
         write_host_url = c.get('env', 'CGP_API_WRITE_HOST', 'https://db.conversations.xyz')
         write_host_port = c.get('env', 'CGP_API_WRITE_PORT', '443')
         url = f"{write_host_url}:{write_host_port}/api/v1/conversation/record/{id}"
@@ -78,6 +78,7 @@ class ApiLib:
         headers = {
             "Accept": "application/json",
             "Accept-Language": "en_US",
+            "Authorization": "Bearer %s" % (str(api_key)),
         }
 
         http_timeout = Utils._float(c.get('env', 'HTTP_TIMEOUT', 60))

--- a/conversationgenome/base/validator.py
+++ b/conversationgenome/base/validator.py
@@ -24,6 +24,7 @@ import logging
 import os
 import re
 import threading
+import time
 from traceback import print_exception
 from typing import Dict, List, Tuple
 
@@ -133,6 +134,21 @@ class BaseValidatorNeuron(BaseNeuron):
         self.thread: threading.Thread = None
         self.lock = asyncio.Lock()
 
+        # Failsafe dispatch throttle: guarantees miners are never hit faster
+        # than min_seconds_between_dispatches, regardless of num_concurrent_forwards
+        # or how fast forward() happens to complete (e.g. due to a bad config
+        # or fast-failing requests removing the natural network-latency pacing).
+        self._dispatch_lock = asyncio.Lock()
+        self._last_dispatch_time = 0.0
+        self._min_dispatch_interval = c.get("validator", "min_seconds_between_dispatches", 12.0)
+
+        if self.config.neuron.num_concurrent_forwards > 1:
+            bt.logging.warning(
+                f"neuron.num_concurrent_forwards is set to {self.config.neuron.num_concurrent_forwards} "
+                "(default is 1). Running multiple forward() loops concurrently can cause miners to be "
+                "queried much more frequently than intended. Verify this is intentional."
+            )
+
     def serve_axon(self):
         """Serve axon to enable external connections."""
 
@@ -158,6 +174,17 @@ class BaseValidatorNeuron(BaseNeuron):
         coroutines = [self.forward() for _ in range(self.config.neuron.num_concurrent_forwards)]
         results = await asyncio.gather(*coroutines)
         return results
+
+    async def throttle_dispatch(self):
+        """Failsafe rate limit: block until at least min_seconds_between_dispatches
+        has passed since the last dispatch. Shared across all concurrent forward()
+        coroutines via _dispatch_lock, so it holds even if num_concurrent_forwards
+        is misconfigured or a task loop completes unusually fast."""
+        async with self._dispatch_lock:
+            wait = self._min_dispatch_interval - (time.monotonic() - self._last_dispatch_time)
+            if wait > 0:
+                await asyncio.sleep(wait)
+            self._last_dispatch_time = time.monotonic()
 
     def run(self):
         """

--- a/conversationgenome/llm/llm_factory.py
+++ b/conversationgenome/llm/llm_factory.py
@@ -1,12 +1,50 @@
+import bittensor as bt
+
 from conversationgenome.ConfigLib import c
 from conversationgenome.llm.LlmLib import LlmLib
+
+LOCKED_LLM_TYPE = "openai"
+_OVERRIDE_ENV_VARS = ["LLM_TYPE_OVERRIDE", "OPENAI_MODEL", "OPENAI_EMBEDDINGS_MODEL_OVERRIDE"]
+
+
+def _present_llm_override_vars() -> list[str]:
+    return [v for v in _OVERRIDE_ENV_VARS if c.get("env", v)]
+
+
+def configure_llm_override_lockdown(netuid: int) -> bool:
+    """Validator-only startup check: on mainnet, LLM provider/model/embeddings-model
+    overrides from .env are ignored so all mainnet validators score with the same
+    in-code default LLM config. On any other netuid, overrides are still honored but
+    a warning is logged so operators notice before running on mainnet.
+    """
+    mainnet_netuid = c.get("network", "mainnet", 33)
+    is_mainnet = netuid == mainnet_netuid
+    c.set("system", "llm_overrides_locked", is_mainnet)
+
+    present = _present_llm_override_vars()
+    if present:
+        if is_mainnet:
+            bt.logging.warning(
+                f"LLM override env var(s) {present} detected on mainnet (netuid={netuid}). "
+                "Overrides are ignored on mainnet; falling back to in-code defaults."
+            )
+        else:
+            bt.logging.warning(
+                f"LLM override env var(s) {present} detected on non-mainnet netuid={netuid}. "
+                "Honoring overrides now, but they will be ignored if this validator runs on mainnet."
+            )
+    return is_mainnet
 
 
 def get_llm_backend(llm_type_override=None) -> LlmLib:
     """
-    Factory function to return the specific LLM implementation 
+    Factory function to return the specific LLM implementation
     based on the LLM_PROVIDER environment variable.
     """
+    if c.get("system", "llm_overrides_locked", False):
+        from .llm_openai import LlmOpenAI
+        return LlmOpenAI(ignore_model_override=True)
+
     if not llm_type_override:
         llm_type_override = c.get("env", "LLM_TYPE_OVERRIDE")
 

--- a/conversationgenome/llm/llm_openai.py
+++ b/conversationgenome/llm/llm_openai.py
@@ -4,14 +4,16 @@ from openai import OpenAI
 from conversationgenome.ConfigLib import c
 from conversationgenome.llm.LlmLib import LlmLib, model_override, reasoning_effort_override, service_tier_override
 
+DEFAULT_MODEL = "gpt-5.2"
+
 
 class LlmOpenAI(LlmLib):
-    def __init__(self):
+    def __init__(self, ignore_model_override: bool = False):
         api_key = c.get('env', "OPENAI_API_KEY")
         if not api_key:
             raise ValueError("OPENAI_API_KEY environment variable not set. Please set it in the .env file or as an environment variable.")
         self.client = OpenAI(api_key=api_key)
-        self.model = c.get('env', "OPENAI_MODEL", "gpt-5.2")
+        self.model = DEFAULT_MODEL if ignore_model_override else c.get('env', "OPENAI_MODEL", DEFAULT_MODEL)
         self.embedding_model = "text-embedding-3-small"
 
 

--- a/conversationgenome/task/SkillCoverageEvaluationTask.py
+++ b/conversationgenome/task/SkillCoverageEvaluationTask.py
@@ -26,6 +26,7 @@ class SkillCoverageTaskInput(BaseModel):
 class SkillCoverageEvaluationTask(Task):
     type: Literal["skill_coverage_evaluation"] = "skill_coverage_evaluation"
     input: Optional[SkillCoverageTaskInput] = None
+    timeout: float = 24    # We double the timeout for this task since it is more token heavy than the other tasks
 
     # Switch between the two mining paths below. True (default) runs a single
     # combined call (LlmLib.skill_request_to_skill_bundle) instead of the full

--- a/conversationgenome/task/Task.py
+++ b/conversationgenome/task/Task.py
@@ -23,6 +23,7 @@ class Task(BaseModel, ABC):
     input: Any = None
     prompt_chain: Optional[List[PromptChainStep]] = None
     example_output: Optional[ExampleOutputUnion] = None
+    timeout: float = 12     # Default timeout for tasks is 12s (Same as Bittensor default)
 
     @abstractmethod
     async def mine(self) -> dict[str, list]:

--- a/conversationgenome/task/TaskLib.py
+++ b/conversationgenome/task/TaskLib.py
@@ -1,4 +1,5 @@
 from typing import Any
+from typing import Optional
 
 from conversationgenome import __version__ as CGP_VERSION
 from conversationgenome.api.ApiLib import ApiLib
@@ -6,7 +7,7 @@ from conversationgenome.ConfigLib import c
 
 
 class TaskLib:
-    async def put_task(self, *, hotkey: str, task_bundle_id: str, task_id: str, neuron_type: str, batch_number: int, data: Any) -> None:
+    async def put_task(self, *, hotkey: str, task_bundle_id: str, task_id: str, neuron_type: str, batch_number: int, data: Any, api_key: Optional[str] = None) -> None:
         llm_type = c.get('llm', 'type')
         llm_type_override = c.get("env", "LLM_TYPE_OVERRIDE")
 
@@ -37,6 +38,6 @@ class TaskLib:
 
         output['data'] = data
         api = ApiLib()
-        result = await api.put_task_data(task_bundle_id, output)
+        result = await api.put_task_data(task_bundle_id, output, api_key=api_key)
 
         return result

--- a/conversationgenome/task/TaskLib.py
+++ b/conversationgenome/task/TaskLib.py
@@ -4,21 +4,25 @@ from typing import Optional
 from conversationgenome import __version__ as CGP_VERSION
 from conversationgenome.api.ApiLib import ApiLib
 from conversationgenome.ConfigLib import c
+from conversationgenome.llm.llm_factory import LOCKED_LLM_TYPE
+from conversationgenome.llm.llm_openai import DEFAULT_MODEL
 
 
 class TaskLib:
     async def put_task(self, *, hotkey: str, task_bundle_id: str, task_id: str, neuron_type: str, batch_number: int, data: Any, api_key: Optional[str] = None) -> None:
-        llm_type = c.get('llm', 'type')
+        locked = c.get("system", "llm_overrides_locked", False)
+
+        llm_type = LOCKED_LLM_TYPE if locked else c.get('llm', 'type')
         llm_type_override = c.get("env", "LLM_TYPE_OVERRIDE")
 
-        if llm_type_override:
+        if llm_type_override and not locked:
             llm_type = llm_type_override
 
-        llm_model = c.get('env', llm_type.upper() + "_MODEL")
+        llm_model = DEFAULT_MODEL if locked else c.get('env', llm_type.upper() + "_MODEL")
         embeddings_model = c.get('llm', 'embeddings_model', "text-embedding-3-large")
         embeddings_model_override = c.get("env", "OPENAI_EMBEDDINGS_MODEL_OVERRIDE")
 
-        if embeddings_model_override:
+        if embeddings_model_override and not locked:
             embeddings_model = embeddings_model_override
 
         output = {

--- a/conversationgenome/task_bundle/TaskBundleLib.py
+++ b/conversationgenome/task_bundle/TaskBundleLib.py
@@ -6,9 +6,9 @@ from conversationgenome.task_bundle.TaskBundle import TaskBundle
 
 
 class TaskBundleLib:
-    async def get_task_bundle(self, hotkey, api_key=None) -> TaskBundle:
+    async def get_task_bundle(self, hotkey, netuid, api_key=None) -> TaskBundle:
         api = ApiLib()
-        task_bundle: TaskBundle = await api.reserve_task_bundle(hotkey, api_key=api_key)
+        task_bundle: TaskBundle = await api.reserve_task_bundle(hotkey, netuid, api_key=api_key)
         
         await task_bundle.setup()
 

--- a/conversationgenome/validator/ValidatorLib.py
+++ b/conversationgenome/validator/ValidatorLib.py
@@ -60,9 +60,9 @@ class ValidatorLib:
             return
         self.readyai_api_key = data['api_key']
 
-    async def reserve_task_bundle(self) -> Optional[TaskBundle]:
+    async def reserve_task_bundle(self, netuid: int) -> Optional[TaskBundle]:
         # Validator requests a full conversation from the API
-        task_bundle: TaskBundle = await self.get_task_bundle()
+        task_bundle: TaskBundle = await self.get_task_bundle(netuid)
 
         if task_bundle:
             bt.logging.info(f"Reserved task bundle.")
@@ -72,18 +72,21 @@ class ValidatorLib:
 
         return None
 
-    async def get_task_bundle(self) -> Optional[TaskBundle]:
+    async def get_task_bundle(self, netuid: int) -> Optional[TaskBundle]:
         hotkey = self.hotkey
 
         if not self.readyai_api_key:
             self.read_api_key()
 
         tbl = TaskBundleLib()
-        raw_task_data: TaskBundle = await tbl.get_task_bundle(hotkey, api_key=self.readyai_api_key)
+        raw_task_data: TaskBundle = await tbl.get_task_bundle(hotkey, netuid, api_key=self.readyai_api_key)
 
         return raw_task_data
 
     async def put_task(self, *, hotkey: str, task_bundle_id: str, task_id: str, neuron_type: str, batch_number: int, data: Any) -> None:
+        if not self.readyai_api_key:
+            self.read_api_key()
+
         tl = TaskLib()
         await tl.put_task(
             hotkey=hotkey,
@@ -92,6 +95,7 @@ class ValidatorLib:
             neuron_type=neuron_type,
             batch_number=batch_number,
             data=data,
+            api_key=self.readyai_api_key,
         )
 
     def update_scores(self, rewards, uids, ema_scores, scores, moving_average_alpha, device, neurons, nonlinear_power):

--- a/conversationgenome/validator/ValidatorLib.py
+++ b/conversationgenome/validator/ValidatorLib.py
@@ -9,7 +9,6 @@ from typing import Optional
 import numpy as np
 
 from conversationgenome.ConfigLib import c
-from conversationgenome.llm.llm_factory import get_llm_backend
 from conversationgenome.mock.MockBt import MockBt
 from conversationgenome.task.TaskLib import TaskLib
 from conversationgenome.task_bundle.TaskBundle import TaskBundle
@@ -33,7 +32,6 @@ class ValidatorLib:
     mode = "test"  # test|local_llm|openai|anthropic
     hotkey = "v1234"
     verbose = False
-    llml = get_llm_backend()
     readyai_api_key = None
 
     def __init__(self):

--- a/env.example
+++ b/env.example
@@ -44,6 +44,14 @@ export OPENAI_EMBEDDINGS_MODEL=text-embedding-3-large
 # Validators: This will determine which API you use to Generate Full Convo Tags and Validate Miner Tags
 # Miners: This will determine which API is used to generate your window tags.
 # Note that the Llama models can be used through Groq and the Claude models can be used through Anthropic
+#
+# LLM_TYPE_OVERRIDE / OPENAI_MODEL / OPENAI_EMBEDDINGS_MODEL_OVERRIDE:
+# Miners: always honored, no restrictions.
+# Validators on mainnet (netuid 33): ignored. A warning is logged and the validator
+#   falls back to the in-code default LLM config so all mainnet validators score
+#   with the same model.
+# Validators on any other netuid (e.g. testnet): honored, but the same warning is
+#   logged so you notice before moving to mainnet.
 #export LLM_TYPE_OVERRIDE=groq
 #export LLM_TYPE_OVERRIDE=anthropic
 #export LLM_TYPE_OVERRIDE=openrouter

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -30,6 +30,7 @@ from conversationgenome.api.models.conversation import Conversation
 from conversationgenome.api.models.conversation_metadata import ConversationMetadata
 from conversationgenome.base.validator import BaseValidatorNeuron
 from conversationgenome.ConfigLib import c
+from conversationgenome.llm.llm_factory import configure_llm_override_lockdown
 from conversationgenome.task.Task import Task
 from conversationgenome.task_bundle.TaskBundle import TaskBundle
 from conversationgenome.utils.Utils import Utils
@@ -63,6 +64,7 @@ class Validator(BaseValidatorNeuron):
 
         super(Validator, self).__init__(config=config)
         c.set("system", "netuid", self.config.netuid)
+        configure_llm_override_lockdown(self.config.netuid)
 
         bt.logging.info("load_state()")
         self.load_state()
@@ -186,7 +188,7 @@ class Validator(BaseValidatorNeuron):
                 validatorHotkey = str(self.axon.wallet.hotkey.ss58_address)
 
                 llm_type_override = c.get("env", "LLM_TYPE_OVERRIDE")
-                if llm_type_override:
+                if llm_type_override and not c.get("system", "llm_overrides_locked", False):
                     llm_type = llm_type_override
                     model = c.get("env", "OPENAI_MODEL")
             except:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -266,10 +266,12 @@ class Validator(BaseValidatorNeuron):
                 # Create a synapse to distribute to miners
                 synapse = conversationgenome.protocol.CgSynapse(cgp_input=[{"task": masked_task}])
 
+                await self.throttle_dispatch()
                 responses = await self.dendrite.forward(
                     axons=self._get_axons_for_uids(miner_uids),
                     synapse=synapse,
                     deserialize=False,
+                    timeout=task.timeout,
                 )
 
                 if self.verbose:
@@ -308,10 +310,12 @@ class Validator(BaseValidatorNeuron):
                 if uids_to_retry:
                     bt.logging.debug(f"Retrying requests for the following UIDs (same synapse): {uids_to_retry}")
 
+                    await self.throttle_dispatch()
                     retry_responses = await self.dendrite.forward(
                         axons=self._get_axons_for_uids(uids_to_retry),
                         synapse=synapse,
                         deserialize=False,
+                        timeout=task.timeout,
                     )
 
                     for i, uid in enumerate(uids_to_retry):

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -194,7 +194,7 @@ class Validator(BaseValidatorNeuron):
 
             for _ in range(number_of_task_bundles):
                 batch_num = random.randint(100000, 9999999)
-                task_bundle: TaskBundle = await vl.reserve_task_bundle()
+                task_bundle: TaskBundle = await vl.reserve_task_bundle(self.config.netuid)
 
                 if not task_bundle:
                     continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,18 @@ load_dotenv(find_dotenv(usecwd=True), override=False)
 # Set to True for faster tests with smaller task bundles
 fast_tests = True
 
+
+@pytest.fixture(autouse=True)
+def reset_llm_overrides_locked():
+    """Some tests (e.g. those constructing a real Validator) exercise the real
+    ConfigLib.state global dict via configure_llm_override_lockdown(), which can leak
+    llm_overrides_locked=True to later tests that read the real (unmocked) c.get. Reset
+    it after every test so state never leaks across the suite."""
+    yield
+    from conversationgenome.ConfigLib import c as real_c
+    real_c.state.setdefault("system", {})["llm_overrides_locked"] = False
+
+
 @pytest.fixture(autouse=True)
 def patch_random_and_config(monkeypatch):
     """Global defaults: deterministic random + sensible c.get map."""
@@ -36,6 +48,7 @@ def patch_random_and_config(monkeypatch):
         ("system", "mode"): "test",
         ("system", "scoring_version"): 0.1,
         ("system", "netuid"): -1,
+        ("system", "llm_overrides_locked"): False,
         # llm section
         ("llm", "type"): "openai",
         ("llm", "embeddings_model"): "text-embedding-3-large",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,6 +154,11 @@ def bare_validator(monkeypatch):
     v.update_scores = lambda *a, **k: None
     v.load_state = lambda: None
 
+    import asyncio as _asyncio
+    v._dispatch_lock = _asyncio.Lock()
+    v._last_dispatch_time = 0.0
+    v._min_dispatch_interval = 0.0
+
     return v
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def fake_libs(monkeypatch):
         def __init__(self):
             self.calls = {"reserve_task_bundle": 0, "put_task": 0}
 
-        async def reserve_task_bundle(self, *, batch_num=None, return_indexed_windows=True):
+        async def reserve_task_bundle(self, netuid=None, *, batch_num=None, return_indexed_windows=True):
             self.calls["reserve_task_bundle"] += 1
             return DummyData.conversation_tagging_task_bundle()
 

--- a/tests/mocks/MockTaskBundle.py
+++ b/tests/mocks/MockTaskBundle.py
@@ -20,6 +20,7 @@ class MockTask:
         self.input.data.indexed_windows = [(0, [(0, "mock line")])]
         self.prompt_chain = []
         self.example_output = {}
+        self.timeout = 12
 
     async def mine(self):
         return {"tags": ["mock_tag"], "vectors": {"mock_tag": [0.1]}}

--- a/tests/test_full_loop.py
+++ b/tests/test_full_loop.py
@@ -59,7 +59,7 @@ def validator_with_mock_metagraph():
         # Validator config
         config = BaseValidatorNeuron.config()
         config.wallet = SimpleNamespace(name="mock_wallet", hotkey="mock_hotkey")
-        config.netuid = 33
+        config.netuid = 138
         config.neuron = SimpleNamespace(
             name="test-validator",
             epoch_length=10,

--- a/tests/unit/test_ApiLib.py
+++ b/tests/unit/test_ApiLib.py
@@ -29,7 +29,7 @@ async def test_when_reserving_conversation_then_conversation_is_returned(mock_co
     mock_requests_post.return_value = mock_response
 
     api = ApiLib()
-    task_bundle = await api.reserve_task_bundle(hotkey=hotkey, api_key=api_key)
+    task_bundle = await api.reserve_task_bundle(hotkey=hotkey, netuid=1111, api_key=api_key)
 
     assert isinstance(task_bundle, TaskBundle)
     assert task_bundle.type == "conversation_tagging"
@@ -51,8 +51,9 @@ async def test_when_reserving_conversation_then_endpoint_is_called_properly(mock
     mock_requests_post.return_value = mock_response
 
     api = ApiLib()
-    task_bundle = await api.reserve_task_bundle(hotkey=hotkey, api_key=api_key)
+    task_bundle = await api.reserve_task_bundle(hotkey=hotkey, netuid=33, api_key=api_key)
 
     args, kwargs = mock_requests_post.call_args
     assert "https://fake.api:443/api/v1/conversation/reserve" in args[0]
+    assert "netuid=33" in args[0]
     assert kwargs["headers"]["Authorization"] == f"Bearer {api_key}"

--- a/tests/unit/test_LlmChutes.py
+++ b/tests/unit/test_LlmChutes.py
@@ -38,7 +38,10 @@ def test_llm_chutes_basic_prompt(mock_config):
 
 def test_llm_factory_chutes_registration():
     with patch('conversationgenome.llm.llm_factory.c') as mock_c:
-        mock_c.get.return_value = "chutes"
+        mock_c.get.side_effect = lambda section, key, default=None: {
+            ("system", "llm_overrides_locked"): False,
+            ("env", "LLM_TYPE_OVERRIDE"): "chutes",
+        }.get((section, key), default)
         with patch('conversationgenome.llm.llm_chutes.OpenAI'), \
              patch('conversationgenome.llm.llm_chutes.c'):
             llm = get_llm_backend()

--- a/tests/unit/test_LlmOpenAI.py
+++ b/tests/unit/test_LlmOpenAI.py
@@ -1,0 +1,46 @@
+from unittest.mock import patch
+
+from conversationgenome.llm.llm_openai import DEFAULT_MODEL
+from conversationgenome.llm.llm_openai import LlmOpenAI
+
+
+def _c_get(overrides):
+    def get(section, key, default=None):
+        return overrides.get((section, key), default)
+    return get
+
+
+@patch("conversationgenome.llm.llm_openai.OpenAI")
+@patch("conversationgenome.llm.llm_openai.c")
+def test_model_override_honored_by_default(mock_c, mock_openai):
+    mock_c.get.side_effect = _c_get({
+        ("env", "OPENAI_API_KEY"): "test-key",
+        ("env", "OPENAI_MODEL"): "gpt-custom",
+    })
+
+    llm = LlmOpenAI()
+
+    assert llm.model == "gpt-custom"
+
+
+@patch("conversationgenome.llm.llm_openai.OpenAI")
+@patch("conversationgenome.llm.llm_openai.c")
+def test_model_override_ignored_when_locked(mock_c, mock_openai):
+    mock_c.get.side_effect = _c_get({
+        ("env", "OPENAI_API_KEY"): "test-key",
+        ("env", "OPENAI_MODEL"): "gpt-custom",
+    })
+
+    llm = LlmOpenAI(ignore_model_override=True)
+
+    assert llm.model == DEFAULT_MODEL
+
+
+@patch("conversationgenome.llm.llm_openai.OpenAI")
+@patch("conversationgenome.llm.llm_openai.c")
+def test_default_model_used_when_no_override_present(mock_c, mock_openai):
+    mock_c.get.side_effect = _c_get({("env", "OPENAI_API_KEY"): "test-key"})
+
+    llm = LlmOpenAI()
+
+    assert llm.model == DEFAULT_MODEL

--- a/tests/unit/test_LlmOpenRouter.py
+++ b/tests/unit/test_LlmOpenRouter.py
@@ -41,7 +41,10 @@ def test_llm_openrouter_basic_prompt(mock_config):
 
 def test_llm_factory_registration():
     with patch('conversationgenome.llm.llm_factory.c') as mock_c:
-        mock_c.get.return_value = "openrouter"
+        mock_c.get.side_effect = lambda section, key, default=None: {
+            ("system", "llm_overrides_locked"): False,
+            ("env", "LLM_TYPE_OVERRIDE"): "openrouter",
+        }.get((section, key), default)
         with patch('conversationgenome.llm.llm_openrouter.OpenAI'), \
              patch('conversationgenome.llm.llm_openrouter.c'):
             llm = get_llm_backend()

--- a/tests/unit/test_TaskBundleLib.py
+++ b/tests/unit/test_TaskBundleLib.py
@@ -37,7 +37,7 @@ async def test_when_getting_task_bundle_then_max_lines_is_respected(mock_config_
         mock_requests_post.return_value = mock_response
 
         tbl = TaskBundleLib()
-        task_bundle: TaskBundle = await tbl.get_task_bundle(hotkey=hotkey, api_key=api_key)
+        task_bundle: TaskBundle = await tbl.get_task_bundle(hotkey=hotkey, netuid=1111, api_key=api_key)
 
         assert len(task_bundle.input.data.lines) == MAX_CONVO_LINES
         assert task_bundle.input.data.lines == DummyData.lines()[0:MAX_CONVO_LINES]

--- a/tests/unit/test_TaskLib.py
+++ b/tests/unit/test_TaskLib.py
@@ -24,6 +24,7 @@ async def test_put_task_basic(mock_c, mock_ApiLib):
         ("env", "OPENAI_EMBEDDINGS_MODEL_OVERRIDE"): None,
         ("llm", "type"): "openai",
         ("llm", "embeddings_model"): "text-embedding-3-large",
+        ("system", "llm_overrides_locked"): False,
     }[(section, key)]
 
     # Setup ApiLib mock
@@ -73,6 +74,7 @@ async def test_put_task_with_overrides(mock_c, mock_ApiLib):
         ("env", "OPENAI_EMBEDDINGS_MODEL_OVERRIDE"): "custom-embedder",
         ("llm", "type"): "openai",
         ("llm", "embeddings_model"): "text-embedding-3-large",
+        ("system", "llm_overrides_locked"): False,
     }[(section, key)]
 
     mock_api_instance = MagicMock()
@@ -97,3 +99,44 @@ async def test_put_task_with_overrides(mock_c, mock_ApiLib):
     assert output["llm_type"] == "anthropic"
     assert output["cgp_version"] == "2.0.0"
     assert output["data"] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+@patch("conversationgenome.task.TaskLib.ApiLib")
+@patch("conversationgenome.task.TaskLib.c")
+@patch("conversationgenome.task.TaskLib.CGP_VERSION", "3.0.0")
+async def test_put_task_overrides_ignored_when_locked(mock_c, mock_ApiLib):
+    # Overrides are present in .env, but llm_overrides_locked is True (mainnet validator) -- they must be ignored.
+    mock_c.get.side_effect = lambda section, key, default=None: {
+        ("env", "LLM_TYPE_OVERRIDE"): "anthropic",
+        ("env", "ANTHROPIC_MODEL"): "claude-3",
+        ("env", "SYSTEM_MODE"): "prod",
+        ("env", "MARKER_ID"): "marker000",
+        ("env", "LLM_TYPE"): "anthropic",
+        ("system", "scoring_version"): "v3",
+        ("system", "netuid"): 33,
+        ("env", "OPENAI_EMBEDDINGS_MODEL_OVERRIDE"): "custom-embedder",
+        ("llm", "type"): "openai",
+        ("llm", "embeddings_model"): "text-embedding-3-large",
+        ("system", "llm_overrides_locked"): True,
+    }[(section, key)]
+
+    mock_api_instance = MagicMock()
+    mock_api_instance.put_task_data = AsyncMock(return_value={"status": "success"})
+    mock_ApiLib.return_value = mock_api_instance
+
+    task_lib = TaskLib()
+    await task_lib.put_task(
+        hotkey="hk3",
+        task_bundle_id="tbid3",
+        task_id="tid3",
+        neuron_type="typeC",
+        batch_number=1,
+        data={},
+    )
+
+    args, kwargs = mock_api_instance.put_task_data.call_args
+    output = args[1]
+    assert output["llm_type"] == "openai"
+    assert output["model"] == "gpt-5.2"
+    assert output["embeddings_model"] == "text-embedding-3-large"

--- a/tests/unit/test_Validator.py
+++ b/tests/unit/test_Validator.py
@@ -1,10 +1,14 @@
+import tempfile
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
 
+from conversationgenome.base.validator import BaseValidatorNeuron
 from tests.mocks.MockTaskBundle import MockTaskBundle
+from tests.mocks.TestValidator import TestValidator
 
 
 @pytest.mark.asyncio
@@ -565,3 +569,37 @@ def test_get_burn_uid(bare_validator):
     assert uid == expected_uid
     v.subtensor.query_subtensor.assert_called_once_with("SubnetOwnerHotkey", params=[v.config.netuid])
     v.subtensor.get_uid_for_hotkey_on_subnet.assert_called_once_with(hotkey_ss58=expected_hotkey, netuid=v.config.netuid)
+
+
+@patch("neurons.validator.configure_llm_override_lockdown")
+def test_init_configures_llm_override_lockdown(mock_configure_lockdown):
+    """Validator.__init__ must wire netuid through to configure_llm_override_lockdown
+    so mainnet validators get the LLM-override lockdown (and testnet/miners don't)."""
+    with patch("conversationgenome.base.neuron.MockMetagraph"), \
+         patch("bittensor.Subtensor"), \
+         patch("bittensor.Wallet") as mock_wallet_class:
+        mock_wallet_instance = MagicMock()
+        mock_wallet_instance.hotkey.ss58_address = "mock_hotkey"
+        mock_wallet_class.return_value = mock_wallet_instance
+
+        config = BaseValidatorNeuron.config()
+        config.wallet = SimpleNamespace(name="mock_wallet", hotkey="mock_hotkey")
+        config.netuid = 33
+        config.neuron = SimpleNamespace(
+            name="test-validator",
+            epoch_length=10,
+            disable_set_weights=True,
+            dont_save_events=True,
+            full_path="/tmp/validator_init_test",
+            device="cpu",
+            axon_off=True,
+            sample_size=2,
+            moving_average_alpha=0.1,
+            num_concurrent_forwards=1,
+        )
+        temp_log_dir = tempfile.mkdtemp()
+        config.logging = SimpleNamespace(logging_dir=temp_log_dir, logging_file="bittensor.log", debug=True, trace=False, logging_level="info", record_log=False)
+
+        TestValidator(config, block_override=100)
+
+        mock_configure_lockdown.assert_called_once_with(33)

--- a/tests/unit/test_Validator.py
+++ b/tests/unit/test_Validator.py
@@ -1,5 +1,3 @@
-import tempfile
-from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -8,7 +6,6 @@ import pytest
 
 from conversationgenome.base.validator import BaseValidatorNeuron
 from tests.mocks.MockTaskBundle import MockTaskBundle
-from tests.mocks.TestValidator import TestValidator
 
 
 @pytest.mark.asyncio
@@ -571,35 +568,29 @@ def test_get_burn_uid(bare_validator):
     v.subtensor.get_uid_for_hotkey_on_subnet.assert_called_once_with(hotkey_ss58=expected_hotkey, netuid=v.config.netuid)
 
 
-@patch("neurons.validator.configure_llm_override_lockdown")
-def test_init_configures_llm_override_lockdown(mock_configure_lockdown):
+def test_init_configures_llm_override_lockdown(monkeypatch):
     """Validator.__init__ must wire netuid through to configure_llm_override_lockdown
-    so mainnet validators get the LLM-override lockdown (and testnet/miners don't)."""
-    with patch("conversationgenome.base.neuron.MockMetagraph"), \
-         patch("bittensor.Subtensor"), \
-         patch("bittensor.Wallet") as mock_wallet_class:
-        mock_wallet_instance = MagicMock()
-        mock_wallet_instance.hotkey.ss58_address = "mock_hotkey"
-        mock_wallet_class.return_value = mock_wallet_instance
+    so mainnet validators get the LLM-override lockdown (and testnet/miners don't).
 
-        config = BaseValidatorNeuron.config()
-        config.wallet = SimpleNamespace(name="mock_wallet", hotkey="mock_hotkey")
-        config.netuid = 33
-        config.neuron = SimpleNamespace(
-            name="test-validator",
-            epoch_length=10,
-            disable_set_weights=True,
-            dont_save_events=True,
-            full_path="/tmp/validator_init_test",
-            device="cpu",
-            axon_off=True,
-            sample_size=2,
-            moving_average_alpha=0.1,
-            num_concurrent_forwards=1,
-        )
-        temp_log_dir = tempfile.mkdtemp()
-        config.logging = SimpleNamespace(logging_dir=temp_log_dir, logging_file="bittensor.log", debug=True, trace=False, logging_level="info", record_log=False)
+    Bypasses the heavy parent init (wallet/subtensor/metagraph) and stubs c.get/c.set
+    the same way test_init_refreshes_commitments_once_at_startup does above -- this
+    must NOT depend on a real COMMITMENT_PRIVATE_KEY from a local .env file, or it
+    passes locally but fails on any CI checkout that has no .env.
+    """
+    import neurons.validator as validator_module
 
-        TestValidator(config, block_override=100)
+    monkeypatch.setattr(BaseValidatorNeuron, "__init__", lambda self, config=None: None)
+    monkeypatch.setattr(validator_module.c, "get", lambda *_a, **_k: "00" * 32)
+    monkeypatch.setattr(validator_module.c, "set", lambda *_a, **_k: None)
 
-        mock_configure_lockdown.assert_called_once_with(33)
+    mock_configure_lockdown = MagicMock()
+    monkeypatch.setattr(validator_module, "configure_llm_override_lockdown", mock_configure_lockdown)
+
+    instance = validator_module.Validator.__new__(validator_module.Validator)
+    instance.config = type("C", (), {"netuid": 33, "neuron": type("N", (), {"sample_size": 6})()})()
+    instance.load_state = lambda: None
+    instance.refresh_miner_endpoints = MagicMock()
+
+    validator_module.Validator.__init__(instance)
+
+    mock_configure_lockdown.assert_called_once_with(33)

--- a/tests/unit/test_Validator.py
+++ b/tests/unit/test_Validator.py
@@ -35,7 +35,7 @@ async def test_forward_respects_max_convo_lines(mock_config_get, bare_validator,
     validator.config.neuron.sample_size = 3
     validator.metagraph.n.item.return_value = 3
 
-    async def reserve_task_bundle_side_effect():
+    async def reserve_task_bundle_side_effect(netuid=None):
         bundle = MockTaskBundle(num_tasks=override_config[("validator", "max_convo_lines")])
         max_lines = override_config[("validator", "max_convo_lines")]
         bundle.input.data.lines = bundle.input.data.lines[:max_lines]

--- a/tests/unit/test_ValidatorLib.py
+++ b/tests/unit/test_ValidatorLib.py
@@ -16,7 +16,7 @@ def validator():
 async def test_when_reserving_then_task_bundle_returned(monkeypatch, validator):
     monkeypatch.setattr(validator, "get_task_bundle", AsyncMock(return_value=DummyData.conversation_tagging_task_bundle()))
 
-    result = await validator.reserve_task_bundle()
+    result = await validator.reserve_task_bundle(1111)
 
     assert result is not None
     assert isinstance(result, TaskBundle)
@@ -26,6 +26,6 @@ async def test_when_reserving_then_task_bundle_returned(monkeypatch, validator):
 async def test_when_no_conversation_then_none_reserved(monkeypatch, validator):
     monkeypatch.setattr(validator, "get_task_bundle", AsyncMock(return_value=None))
 
-    result = await validator.reserve_task_bundle()
+    result = await validator.reserve_task_bundle(1111)
 
     assert result is None

--- a/tests/unit/test_llm_factory.py
+++ b/tests/unit/test_llm_factory.py
@@ -1,0 +1,136 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from conversationgenome.llm.llm_factory import _present_llm_override_vars
+from conversationgenome.llm.llm_factory import configure_llm_override_lockdown
+from conversationgenome.llm.llm_factory import get_llm_backend
+from conversationgenome.llm.llm_openai import LlmOpenAI
+
+
+def _c_get(overrides):
+    def get(section, key, default=None):
+        return overrides.get((section, key), default)
+    return get
+
+
+@patch("conversationgenome.llm.llm_factory.c")
+def test_present_llm_override_vars_none_set(mock_c):
+    mock_c.get.side_effect = _c_get({})
+    assert _present_llm_override_vars() == []
+
+
+@patch("conversationgenome.llm.llm_factory.c")
+def test_present_llm_override_vars_each_detected(mock_c):
+    for var in ["LLM_TYPE_OVERRIDE", "OPENAI_MODEL", "OPENAI_EMBEDDINGS_MODEL_OVERRIDE"]:
+        mock_c.get.side_effect = _c_get({("env", var): "some-value"})
+        assert _present_llm_override_vars() == [var]
+
+
+@patch("conversationgenome.llm.llm_factory.bt")
+@patch("conversationgenome.llm.llm_factory.c")
+def test_configure_lockdown_mainnet_no_override(mock_c, mock_bt):
+    mock_c.get.side_effect = _c_get({("network", "mainnet"): 33})
+    mock_c.set = MagicMock()
+
+    result = configure_llm_override_lockdown(33)
+
+    assert result is True
+    mock_c.set.assert_called_once_with("system", "llm_overrides_locked", True)
+    mock_bt.logging.warning.assert_not_called()
+
+
+@patch("conversationgenome.llm.llm_factory.bt")
+@patch("conversationgenome.llm.llm_factory.c")
+def test_configure_lockdown_mainnet_with_override_warns_and_locks(mock_c, mock_bt):
+    mock_c.get.side_effect = _c_get({
+        ("network", "mainnet"): 33,
+        ("env", "LLM_TYPE_OVERRIDE"): "anthropic",
+    })
+    mock_c.set = MagicMock()
+
+    result = configure_llm_override_lockdown(33)
+
+    assert result is True
+    mock_c.set.assert_called_once_with("system", "llm_overrides_locked", True)
+    mock_bt.logging.warning.assert_called_once()
+    assert "ignored" in mock_bt.logging.warning.call_args[0][0]
+
+
+@patch("conversationgenome.llm.llm_factory.bt")
+@patch("conversationgenome.llm.llm_factory.c")
+def test_configure_lockdown_testnet_with_override_warns_but_allows(mock_c, mock_bt):
+    mock_c.get.side_effect = _c_get({
+        ("network", "mainnet"): 33,
+        ("env", "OPENAI_MODEL"): "gpt-custom",
+    })
+    mock_c.set = MagicMock()
+
+    result = configure_llm_override_lockdown(138)
+
+    assert result is False
+    mock_c.set.assert_called_once_with("system", "llm_overrides_locked", False)
+    mock_bt.logging.warning.assert_called_once()
+    assert "Honoring" in mock_bt.logging.warning.call_args[0][0]
+
+
+@patch("conversationgenome.llm.llm_factory.bt")
+@patch("conversationgenome.llm.llm_factory.c")
+def test_configure_lockdown_testnet_no_override_no_warning(mock_c, mock_bt):
+    mock_c.get.side_effect = _c_get({("network", "mainnet"): 33})
+    mock_c.set = MagicMock()
+
+    result = configure_llm_override_lockdown(138)
+
+    assert result is False
+    mock_bt.logging.warning.assert_not_called()
+
+
+@patch("conversationgenome.llm.llm_openai.OpenAI")
+@patch("conversationgenome.llm.llm_openai.c")
+@patch("conversationgenome.llm.llm_factory.c")
+def test_get_llm_backend_locked_forces_openai_ignoring_explicit_override(mock_factory_c, mock_openai_c, mock_openai_client):
+    mock_factory_c.get.side_effect = _c_get({("system", "llm_overrides_locked"): True})
+    mock_openai_c.get.side_effect = _c_get({("env", "OPENAI_API_KEY"): "test-key"})
+
+    llm = get_llm_backend(llm_type_override="anthropic")
+
+    assert isinstance(llm, LlmOpenAI)
+    assert llm.model == "gpt-5.2"
+
+
+@patch("conversationgenome.llm.llm_openai.OpenAI")
+@patch("conversationgenome.llm.llm_openai.c")
+@patch("conversationgenome.llm.llm_factory.c")
+def test_get_llm_backend_unlocked_honors_override(mock_factory_c, mock_openai_c, mock_openai_client):
+    mock_factory_c.get.side_effect = _c_get({
+        ("system", "llm_overrides_locked"): False,
+        ("env", "LLM_TYPE_OVERRIDE"): None,
+    })
+
+    llm = get_llm_backend(llm_type_override=None)
+
+    assert isinstance(llm, LlmOpenAI)
+
+
+@patch("conversationgenome.llm.llm_factory.c")
+def test_get_llm_backend_never_locked_for_miner_process(mock_c):
+    """Miners never call configure_llm_override_lockdown, so the flag defaults to False
+    and get_llm_backend() honors overrides exactly as before."""
+    with patch("conversationgenome.llm.llm_openrouter.c") as mock_openrouter_c, \
+         patch("conversationgenome.llm.llm_openrouter.OpenAI"):
+        mock_c.get.side_effect = _c_get({
+            ("system", "llm_overrides_locked"): False,
+            ("env", "LLM_TYPE_OVERRIDE"): "openrouter",
+        })
+        mock_openrouter_c.get.side_effect = _c_get({
+            ("env", "OPENROUTER_API_KEY"): "test-key",
+            ("env", "OPENROUTER_MODEL"): "test-model",
+        })
+
+        from conversationgenome.llm.llm_openrouter import LlmOpenRouter
+
+        llm = get_llm_backend()
+
+        assert isinstance(llm, LlmOpenRouter)


### PR DESCRIPTION
# Summary
- Add a per-task timeout property (default 12s) to the base Task class so dendrite.forward() calls use a configurable, task-specific timeout instead of the unused default. SkillCoverageEvaluationTask overrides it to 24s since it's more token-heavy than the other task types.
- Add a dispatch-throttle failsafe (throttle_dispatch(), default 12s minimum between dispatches) in BaseValidatorNeuron to guarantee miners are never queried faster than a safe rate, regardless of neuron.num_concurrent_forwards misconfiguration or unusually fast task loops. Also logs a warning at startup if num_concurrent_forwards > 1, since that's a likely root cause of miner-spamming behavior.
- Prepare ApiLib for stricter upcoming API enforcement (non-breaking with the current API)
- Disable LLM provider override and LLM model override for validators running on mainnet. This will prevent potential compatibility issues as well as ensuring a fairer competition environment for miners.